### PR TITLE
fix: refatorar componente Checkbox para usar radix-vue e defineModel

### DIFF
--- a/frontend/src/components/ui/checkbox/Checkbox.vue
+++ b/frontend/src/components/ui/checkbox/Checkbox.vue
@@ -1,30 +1,25 @@
-<script setup lang="ts">
-import type { CheckboxRootEmits, CheckboxRootProps } from "reka-ui"
-import type { HTMLAttributes } from "vue"
-import { reactiveOmit } from "@vueuse/core"
-import { Check } from "lucide-vue-next"
-import { CheckboxIndicator, CheckboxRoot, useForwardPropsEmits } from "reka-ui"
-import { cn } from "@/lib/utils"
+<script lang="ts" setup>
+import {CheckboxIndicator, CheckboxRoot} from "radix-vue"
+import {Check} from "lucide-vue-next"
+import {cn} from "@/lib/utils"
 
-const props = defineProps<CheckboxRootProps & { class?: HTMLAttributes["class"] }>()
-const emits = defineEmits<CheckboxRootEmits>()
+const checked = defineModel<boolean>('checked')
 
-const delegatedProps = reactiveOmit(props, "class")
-
-const forwarded = useForwardPropsEmits(delegatedProps, emits)
+const props = defineProps<{
+  class?: string
+}>()
 </script>
 
 <template>
   <CheckboxRoot
-    v-bind="forwarded"
-    :class="
+      v-model:checked="checked"
+      :class="
       cn('grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
          props.class)"
+      v-bind="$attrs"
   >
     <CheckboxIndicator class="grid place-content-center text-current">
-      <slot>
-        <Check class="h-4 w-4" />
-      </slot>
+      <Check class="h-4 w-4"/>
     </CheckboxIndicator>
   </CheckboxRoot>
 </template>


### PR DESCRIPTION
Substituída a biblioteca reka-ui por radix-vue e implementado defineModel para garantir o binding bidirecional correto (v-model).

- Resolve o bug de salvamento dos dias permitidos no cadastro de protocolos.
- Corrige visualmente o comportamento de checkboxes em outras áreas da aplicação (dias de atendimento e modal de tags), garantindo que reflitam o estado correto.

Fixes #5