### PR TITLE
refactor: decompor useAppStore em stores especializadas

### DIFF
--- a/frontend/src/stores/agendamento.ts
+++ b/frontend/src/stores/agendamento.ts
@@ -1,0 +1,134 @@
+import {defineStore} from 'pinia'
+import {ref} from 'vue'
+import api from '@/services/api'
+import {toast} from 'vue-sonner'
+import type {Agendamento, StatusFarmacia, StatusPaciente} from '@/types'
+
+export const useAgendamentoStore = defineStore('agendamento', () => {
+  const agendamentos = ref<Agendamento[]>([])
+
+  function getAgendamentosDoDia(data: string) {
+    return agendamentos.value.filter(a => a.data === data)
+  }
+
+  async function fetchAgendamentos(inicio?: string, fim?: string) {
+    try {
+      const params: any = {}
+      if (inicio) params.data_inicio = inicio
+      if (fim) params.data_fim = fim
+
+      const res = await api.get('/api/agendamentos', {params})
+      agendamentos.value = res.data
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async function adicionarAgendamento(agendamento: any) {
+    try {
+      const res = await api.post('/api/agendamentos', agendamento)
+      agendamentos.value.push(res.data)
+      return res.data
+    } catch (e) {
+      toast.error("Erro ao criar agendamento")
+      throw e
+    }
+  }
+
+  async function atualizarStatusAgendamento(
+    id: string,
+    status: StatusPaciente,
+    detalhes?: any
+  ) {
+    try {
+      const payload: any = {status}
+      if (detalhes) payload.detalhes = detalhes
+      else payload.detalhes = null
+
+      const res = await api.put(`/api/agendamentos/${id}`, payload)
+
+      const idx = agendamentos.value.findIndex(a => a.id === id)
+      if (idx !== -1) agendamentos.value[idx] = res.data
+
+      toast.success(`Status atualizado para: ${status}`)
+    } catch (e) {
+      toast.error("Erro ao atualizar status")
+    }
+  }
+
+  async function atualizarStatusFarmacia(id: string, status: StatusFarmacia) {
+    try {
+      const res = await api.put(`/api/agendamentos/${id}`, {statusFarmacia: status})
+      const idx = agendamentos.value.findIndex(a => a.id === id)
+      if (idx !== -1) agendamentos.value[idx] = res.data
+      toast.success("Status farmácia atualizado")
+    } catch (e) {
+      toast.error("Erro na atualização")
+    }
+  }
+
+  async function atualizarHorarioPrevisao(id: string, horario: string) {
+    try {
+      const res = await api.put(`/api/agendamentos/${id}`, {horarioPrevisaoEntrega: horario})
+      const idx = agendamentos.value.findIndex(a => a.id === id)
+      if (idx !== -1) agendamentos.value[idx] = res.data
+    } catch (e) {
+      toast.error("Erro ao atualizar horário")
+    }
+  }
+
+  async function remarcarAgendamento(idOriginal: string, novaData: string, novoHorario: string, motivo: string) {
+    try {
+      const detalhesPayload = {
+        tipo: 'remarcacao', motivo: motivo, data_nova: novaData
+      }
+
+      await atualizarStatusAgendamento(idOriginal, 'remarcado', detalhesPayload)
+
+      const original = agendamentos.value.find(a => a.id === idOriginal)
+      if (!original) return
+
+      await adicionarAgendamento({
+        pacienteId: original.pacienteId,
+        data: novaData,
+        turno: parseInt(novoHorario.split(':')[0]) < 13 ? 'manha' : 'tarde',
+        horarioInicio: novoHorario,
+        horarioFim: original.horarioFim,
+        status: 'agendado',
+        statusFarmacia: 'pendente',
+        encaixe: true,
+        observacoes: `Remarcado de ${original.data}. Motivo: ${motivo}`,
+        cicloAtual: original.cicloAtual,
+        diaCiclo: original.diaCiclo
+      })
+      toast.success("Agendamento remarcado")
+    } catch (e) {
+      toast.error("Erro ao remarcar")
+    }
+  }
+
+  async function atualizarTagsAgendamento(id: string, tags: string[]) {
+    try {
+      const res = await api.put(`/api/agendamentos/${id}`, {tags})
+      const idx = agendamentos.value.findIndex(a => a.id === id)
+      if (idx !== -1) agendamentos.value[idx] = res.data
+      toast.success("Tags atualizadas")
+    } catch (e) {
+      console.error(e)
+      toast.error("Erro ao salvar tags")
+      throw e
+    }
+  }
+
+  return {
+    agendamentos,
+    getAgendamentosDoDia,
+    fetchAgendamentos,
+    adicionarAgendamento,
+    atualizarStatusAgendamento,
+    atualizarStatusFarmacia,
+    atualizarHorarioPrevisao,
+    remarcarAgendamento,
+    atualizarTagsAgendamento
+  }
+})

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -1,134 +1,63 @@
-import {defineStore} from 'pinia'
-import {ref} from 'vue'
-import api from '@/services/api'
-import {toast} from 'vue-sonner'
-import type {
-  Agendamento,
-  ConfigStatus,
-  Paciente,
-  ParametrosAgendamento,
-  PrescricaoMedica,
-  Protocolo,
-  StatusFarmacia,
-  StatusPaciente
-} from '@/types'
-
-const defaultStatusConfig: ConfigStatus[] = [{
-  id: 'agendado', label: 'Agendado', cor: 'bg-slate-500 text-white hover:bg-slate-600', tipo: 'paciente'
-}, {
-  id: 'em-triagem', label: 'Em Triagem', cor: 'bg-blue-500 text-white hover:bg-blue-600', tipo: 'paciente'
-}, {
-  id: 'aguardando-consulta',
-  label: 'Aguardando Consulta',
-  cor: 'bg-indigo-500 text-white hover:bg-indigo-600',
-  tipo: 'paciente'
-}, {
-  id: 'aguardando-exame',
-  label: 'Aguardando Exame',
-  cor: 'bg-violet-500 text-white hover:bg-violet-600',
-  tipo: 'paciente'
-}, {
-  id: 'aguardando-medicamento',
-  label: 'Aguardando Medicação',
-  cor: 'bg-purple-500 text-white hover:bg-purple-600',
-  tipo: 'paciente'
-}, {
-  id: 'em-infusao', label: 'Em Infusão', cor: 'bg-green-600 text-white hover:bg-green-700', tipo: 'paciente'
-}, {
-  id: 'pos-qt', label: 'Pós-QT', cor: 'bg-emerald-600 text-white hover:bg-emerald-700', tipo: 'paciente'
-}, {
-  id: 'concluido', label: 'Concluído', cor: 'bg-teal-600 text-white hover:bg-teal-700', tipo: 'paciente'
-}, {
-  id: 'internado', label: 'Internado', cor: 'bg-orange-500 text-white hover:bg-orange-600', tipo: 'paciente'
-}, {
-  id: 'suspenso', label: 'Suspenso', cor: 'bg-red-600 text-white hover:bg-red-700', tipo: 'paciente'
-}, {
-  id: 'ausente', label: 'Ausente', cor: 'bg-rose-600 text-white hover:bg-rose-700', tipo: 'paciente'
-}, {
-  id: 'intercorrencia', label: 'Intercorrência', cor: 'bg-amber-500 text-white hover:bg-amber-600', tipo: 'paciente'
-}, {id: 'obito', label: 'Óbito', cor: 'bg-gray-900 text-white hover:bg-black', tipo: 'paciente'}, {
-  id: 'remarcado', label: 'Remarcado', cor: 'bg-gray-200 text-gray-500 border-gray-300', tipo: 'paciente'
-}, {id: 'pendente', label: 'Pendente', cor: 'bg-gray-500 text-white', tipo: 'farmacia'}, {
-  id: 'em-preparacao', label: 'Em Preparação', cor: 'bg-blue-500 text-white', tipo: 'farmacia'
-}, {id: 'pronta', label: 'Pronta', cor: 'bg-green-500 text-white', tipo: 'farmacia'}, {
-  id: 'enviada', label: 'Enviada', cor: 'bg-purple-600 text-white', tipo: 'farmacia'
-}]
+import { defineStore, storeToRefs } from 'pinia'
+import { toast } from 'vue-sonner'
+import { usePacienteStore } from './paciente'
+import { useAgendamentoStore } from './agendamento'
+import { useConfiguracaoStore } from './configuracao'
+import { useProtocoloStore } from './protocolo'
+import { usePrescricaoStore } from './prescricao'
 
 export const useAppStore = defineStore('app', () => {
-  const pacientes = ref<Paciente[]>([])
-  const totalPacientes = ref(0)
-  const resultadosBusca = ref<Paciente[]>([])
-  const agendamentos = ref<Agendamento[]>([])
-  const protocolos = ref<Protocolo[]>([])
-  const prescricoes = ref<PrescricaoMedica[]>([])
-  const statusConfig = ref<ConfigStatus[]>(defaultStatusConfig)
+  const pacienteStore = usePacienteStore()
+  const agendamentoStore = useAgendamentoStore()
+  const configuracaoStore = useConfiguracaoStore()
+  const protocoloStore = useProtocoloStore()
+  const prescricaoStore = usePrescricaoStore()
 
-  const parametros = ref<ParametrosAgendamento>(
-    {
-    horarioAbertura: '',
-    horarioFechamento: '',
-    diasFuncionamento: [],
-    gruposInfusao: {
-      rapido: {vagas: 0, duracao: ''},
-      medio: {vagas: 0, duracao: ''},
-      longo: {vagas: 0, duracao: ''}
-    },
-    tags: []
-  })
+  const { pacientes, totalPacientes, resultadosBusca } = storeToRefs(pacienteStore)
+  const { agendamentos } = storeToRefs(agendamentoStore)
+  const { statusConfig, parametros } = storeToRefs(configuracaoStore)
+  const { protocolos } = storeToRefs(protocoloStore)
+  const { prescricoes } = storeToRefs(prescricaoStore)
 
+  const {
+    getStatusConfig,
+    fetchConfiguracoes,
+    salvarConfiguracoes
+  } = configuracaoStore
 
-  function getPacienteById(id: string) {
-    const p = pacientes.value.find(p => p.id === id)
-    if (p && !p.idade && p.dataNascimento) {
-      const nascimento = new Date(p.dataNascimento)
-      const hoje = new Date()
-      let idade = hoje.getFullYear() - nascimento.getFullYear()
-      const m = hoje.getMonth() - nascimento.getMonth()
-      if (m < 0 || (m === 0 && hoje.getDate() < nascimento.getDate())) {
-        idade--
-      }
-      p.idade = idade
-    }
-    return p
-  }
+  const {
+    getPacienteById,
+    fetchPacientes,
+    buscarPacientesDropdown,
+    adicionarPaciente,
+    atualizarPaciente
+  } = pacienteStore
 
-  function getProtocoloById(id: string) {
-    return protocolos.value.find(p => p.id === id)
-  }
+  const {
+    getProtocoloById,
+    fetchProtocolos,
+    adicionarProtocolo,
+    atualizarProtocolo,
+    desativarProtocolo
+  } = protocoloStore
 
-  function getStatusConfig(id: string) {
-    return statusConfig.value.find(s => s.id === id) || defaultStatusConfig[0]
-  }
+  const {
+    getPrescricoesPorPaciente,
+    getProtocoloPeloHistorico,
+    fetchPrescricoes,
+    adicionarPrescricao
+  } = prescricaoStore
 
-  function getAgendamentosDoDia(data: string) {
-    return agendamentos.value.filter(a => a.data === data)
-  }
-
-  function getPrescricoesPorPaciente(pacienteId: string) {
-    return prescricoes.value.filter(p => p.pacienteId === pacienteId)
-  }
-
-  function getProtocoloPeloHistorico(pacienteId: string) {
-    const lista = prescricoes.value.filter(p => p.pacienteId === pacienteId)
-
-    if (lista.length === 0) return null
-
-    const ultima = lista.sort((a, b) =>
-      new Date(b.dataPrescricao).getTime() - new Date(a.dataPrescricao).getTime()
-    )[0]
-
-    if (ultima.protocoloId) {
-      const proto = protocolos.value.find(p => p.id === ultima.protocoloId)
-      if (proto) return proto
-    }
-
-    if (ultima.protocolo) {
-      return {nome: ultima.protocolo} as any
-    }
-
-    return null
-  }
-
+  const {
+    getAgendamentosDoDia,
+    fetchAgendamentos,
+    adicionarAgendamento,
+    atualizarStatusAgendamento,
+    atualizarStatusFarmacia,
+    atualizarHorarioPrevisao,
+    remarcarAgendamento,
+    atualizarTagsAgendamento
+  } = agendamentoStore
 
   async function fetchInitialData() {
     try {
@@ -138,249 +67,6 @@ export const useAppStore = defineStore('app', () => {
     } catch (error) {
       console.error("Erro ao carregar dados iniciais", error)
       toast.error("Erro de conexão ao carregar dados.")
-    }
-  }
-
-  async function fetchPacientes(page = 1, size = 10, termo = '') {
-    try {
-      const params: any = {page, size}
-      if (termo) params.termo = termo
-
-      const res = await api.get('/api/pacientes', {params})
-
-      pacientes.value = res.data.items
-      totalPacientes.value = res.data.total
-
-    } catch (e) {
-      console.error(e)
-    }
-  }
-
-  async function buscarPacientesDropdown(termo: string) {
-    if (!termo || termo.length < 2) {
-      resultadosBusca.value = []
-      return
-    }
-    try {
-      const res = await api.get('/api/pacientes', {params: {termo, page: 1, size: 20}})
-      resultadosBusca.value = res.data.items
-    } catch (e) {
-      console.error(e)
-    }
-  }
-
-  async function fetchProtocolos() {
-    try {
-      const res = await api.get('/api/protocolos', {params: {ativo: true}})
-      protocolos.value = res.data
-    } catch (e) {
-      console.error(e)
-    }
-  }
-
-  async function fetchAgendamentos(inicio?: string, fim?: string) {
-    try {
-      const params: any = {}
-      if (inicio) params.data_inicio = inicio
-      if (fim) params.data_fim = fim
-
-      const res = await api.get('/api/agendamentos', {params})
-      agendamentos.value = res.data
-    } catch (e) {
-      console.error(e)
-    }
-  }
-
-  async function fetchConfiguracoes() {
-    try {
-      const res = await api.get('/api/configuracoes')
-      parametros.value = res.data
-    } catch (e) {
-    console.error("Erro na API de configurações:", e)
-    throw e
-    }
-  }
-
-  async function salvarConfiguracoes(dados: ParametrosAgendamento) {
-    try {
-      const res = await api.put('/api/configuracoes', dados)
-      parametros.value = res.data
-      toast.success("Configurações salvas com sucesso")
-    } catch (e) {
-      console.error(e)
-      toast.error("Erro ao salvar configurações")
-      throw e
-    }
-  }
-
-  async function adicionarPaciente(paciente: any) {
-    try {
-      const res = await api.post('/api/pacientes', paciente)
-      pacientes.value.push(res.data)
-      // toast.success("Paciente cadastrado com sucesso")
-      return res.data
-    } catch (e) {
-      // toast.error("Erro ao cadastrar paciente")
-      throw e
-    }
-  }
-
-  async function atualizarPaciente(id: string, dados: any) {
-    try {
-      const res = await api.put(`/api/pacientes/${id}`, dados)
-      const idx = pacientes.value.findIndex(p => p.id === id)
-      if (idx !== -1) pacientes.value[idx] = res.data
-      toast.success("Dados do paciente atualizados")
-    } catch (e) {
-      toast.error("Erro ao atualizar paciente")
-    }
-  }
-
-  async function adicionarAgendamento(agendamento: any) {
-    try {
-      const res = await api.post('/api/agendamentos', agendamento)
-      agendamentos.value.push(res.data)
-      // Recarregar lista para garantir ordenação
-      return res.data
-    } catch (e) {
-      toast.error("Erro ao criar agendamento")
-      throw e
-    }
-  }
-
-  async function atualizarStatusAgendamento(
-  id: string,
-  status: StatusPaciente,
-  detalhes?: any
-) {
-    try {
-      const payload: any = {status}
-      if (detalhes) payload.detalhes = detalhes
-      else payload.detalhes = null
-
-      const res = await api.put(`/api/agendamentos/${id}`, payload)
-
-      const idx = agendamentos.value.findIndex(a => a.id === id)
-      if (idx !== -1) agendamentos.value[idx] = res.data
-
-      toast.success(`Status atualizado para: ${status}`)
-    } catch (e) {
-      toast.error("Erro ao atualizar status")
-    }
-  }
-
-  async function atualizarStatusFarmacia(id: string, status: StatusFarmacia) {
-    try {
-      const res = await api.put(`/api/agendamentos/${id}`, {statusFarmacia: status})
-      const idx = agendamentos.value.findIndex(a => a.id === id)
-      if (idx !== -1) agendamentos.value[idx] = res.data
-      toast.success("Status farmácia atualizado")
-    } catch (e) {
-      toast.error("Erro na atualização")
-    }
-  }
-
-  async function atualizarHorarioPrevisao(id: string, horario: string) {
-    try {
-      const res = await api.put(`/api/agendamentos/${id}`, {horarioPrevisaoEntrega: horario})
-      const idx = agendamentos.value.findIndex(a => a.id === id)
-      if (idx !== -1) agendamentos.value[idx] = res.data
-    } catch (e) {
-      toast.error("Erro ao atualizar horário")
-    }
-  }
-
-  async function remarcarAgendamento(idOriginal: string, novaData: string, novoHorario: string, motivo: string) {
-    // Rever lógica de remarcação. Foi implementada no Backend?
-
-    try {
-      const detalhesPayload = {
-        tipo: 'remarcacao', motivo: motivo, data_nova: novaData
-      }
-
-      await atualizarStatusAgendamento(idOriginal, 'remarcado', detalhesPayload)
-
-      const original = agendamentos.value.find(a => a.id === idOriginal)
-      if (!original) return
-
-      await adicionarAgendamento({
-        pacienteId: original.pacienteId,
-        data: novaData,
-        turno: parseInt(novoHorario.split(':')[0]) < 13 ? 'manha' : 'tarde',
-        horarioInicio: novoHorario,
-        horarioFim: original.horarioFim, // Idealmente recalcular
-        status: 'agendado',
-        statusFarmacia: 'pendente',
-        encaixe: true,
-        observacoes: `Remarcado de ${original.data}. Motivo: ${motivo}`,
-        cicloAtual: original.cicloAtual,
-        diaCiclo: original.diaCiclo
-      })
-      toast.success("Agendamento remarcado")
-    } catch (e) {
-      toast.error("Erro ao remarcar")
-    }
-  }
-
-  async function atualizarTagsAgendamento(id: string, tags: string[]) {
-    try {
-      const res = await api.put(`/api/agendamentos/${id}`, {tags})
-      const idx = agendamentos.value.findIndex(a => a.id === id)
-      if (idx !== -1) agendamentos.value[idx] = res.data
-      toast.success("Tags atualizadas")
-    } catch (e) {
-      console.error(e)
-      toast.error("Erro ao salvar tags")
-      throw e
-    }
-  }
-
-  async function adicionarProtocolo(protocolo: any) {
-    try {
-      const res = await api.post('/api/protocolos', protocolo)
-      protocolos.value.push(res.data)
-    } catch (e) {
-      toast.error("Erro ao salvar protocolo")
-    }
-  }
-
-  async function atualizarProtocolo(id: string, dados: any) {
-    try {
-      const res = await api.put(`/api/protocolos/${id}`, dados)
-      const idx = protocolos.value.findIndex(p => p.id === id)
-      if (idx !== -1) protocolos.value[idx] = res.data
-    } catch (e) {
-      toast.error("Erro ao atualizar protocolo")
-    }
-  }
-
-  async function desativarProtocolo(id: string) {
-    try {
-      await api.delete(`/api/protocolos/${id}`)
-      const idx = protocolos.value.findIndex(p => p.id === id)
-      if (idx !== -1) protocolos.value[idx].ativo = false
-    } catch (e) {
-      toast.error("Erro ao desativar")
-    }
-  }
-
-  async function fetchPrescricoes(pacienteId: string) {
-    try {
-      const res = await api.get(`/api/prescricoes/paciente/${pacienteId}`)
-      prescricoes.value = prescricoes.value.filter(p => p.pacienteId !== pacienteId).concat(res.data)
-    } catch (e) {
-      console.error(e)
-    }
-  }
-
-  async function adicionarPrescricao(prescricao: any) {
-    try {
-      const res = await api.post('/api/prescricoes', prescricao)
-      prescricoes.value.push(res.data)
-      return res.data
-    } catch (e) {
-      toast.error("Erro ao criar prescrição")
-      throw e
     }
   }
 

--- a/frontend/src/stores/configuracao.ts
+++ b/frontend/src/stores/configuracao.ts
@@ -1,0 +1,165 @@
+import {defineStore} from 'pinia'
+import {ref} from 'vue'
+import api from '@/services/api'
+import {toast} from 'vue-sonner'
+import type {ConfigStatus, ParametrosAgendamento} from '@/types'
+
+const defaultStatusConfig: ConfigStatus[] = [
+  {
+    id: 'agendado',
+    label: 'Agendado',
+    cor: 'bg-slate-500 text-white hover:bg-slate-600',
+    tipo: 'paciente'
+  },
+  {
+    id: 'em-triagem',
+    label: 'Em Triagem',
+    cor: 'bg-blue-500 text-white hover:bg-blue-600',
+    tipo: 'paciente'
+  },
+  {
+    id: 'aguardando-consulta',
+    label: 'Aguardando Consulta',
+    cor: 'bg-indigo-500 text-white hover:bg-indigo-600',
+    tipo: 'paciente'
+  },
+  {
+    id: 'aguardando-exame',
+    label: 'Aguardando Exame',
+    cor: 'bg-violet-500 text-white hover:bg-violet-600',
+    tipo: 'paciente'
+  },
+  {
+    id: 'aguardando-medicamento',
+    label: 'Aguardando Medicação',
+    cor: 'bg-purple-500 text-white hover:bg-purple-600',
+    tipo: 'paciente'
+  },
+  {
+    id: 'em-infusao',
+    label: 'Em Infusão',
+    cor: 'bg-green-600 text-white hover:bg-green-700',
+    tipo: 'paciente'
+  },
+  {
+    id: 'pos-qt',
+    label: 'Pós-QT',
+    cor: 'bg-emerald-600 text-white hover:bg-emerald-700',
+    tipo: 'paciente'
+  },
+  {
+    id: 'concluido',
+    label: 'Concluído',
+    cor: 'bg-teal-600 text-white hover:bg-teal-700',
+    tipo: 'paciente'
+  },
+  {
+    id: 'internado',
+    label: 'Internado',
+    cor: 'bg-orange-500 text-white hover:bg-orange-600',
+    tipo: 'paciente'
+  },
+  {
+    id: 'suspenso',
+    label: 'Suspenso',
+    cor: 'bg-red-600 text-white hover:bg-red-700',
+    tipo: 'paciente'
+  },
+  {
+    id: 'ausente',
+    label: 'Ausente',
+    cor: 'bg-rose-600 text-white hover:bg-rose-700',
+    tipo: 'paciente'
+  },
+  {
+    id: 'intercorrencia',
+    label: 'Intercorrência',
+    cor: 'bg-amber-500 text-white hover:bg-amber-600',
+    tipo: 'paciente'
+  },
+  {
+    id: 'obito',
+    label: 'Óbito',
+    cor: 'bg-gray-900 text-white hover:bg-black',
+    tipo: 'paciente'
+  },
+  {
+    id: 'remarcado',
+    label: 'Remarcado',
+    cor: 'bg-gray-200 text-gray-500 border-gray-300',
+    tipo: 'paciente'
+  },
+  {
+    id: 'pendente',
+    label: 'Pendente',
+    cor: 'bg-gray-500 text-white',
+    tipo: 'farmacia'
+  },
+  {
+    id: 'em-preparacao',
+    label: 'Em Preparação',
+    cor: 'bg-blue-500 text-white',
+    tipo: 'farmacia'
+  },
+  {
+    id: 'pronta',
+    label: 'Pronta',
+    cor: 'bg-green-500 text-white',
+    tipo: 'farmacia'
+  },
+  {
+    id: 'enviada',
+    label: 'Enviada',
+    cor: 'bg-purple-600 text-white',
+    tipo: 'farmacia'
+  }
+]
+
+export const useConfiguracaoStore = defineStore('configuracao', () => {
+  const statusConfig = ref<ConfigStatus[]>(defaultStatusConfig)
+  const parametros = ref<ParametrosAgendamento>({
+    horarioAbertura: '',
+    horarioFechamento: '',
+    diasFuncionamento: [],
+    gruposInfusao: {
+      rapido: {vagas: 0, duracao: ''},
+      medio: {vagas: 0, duracao: ''},
+      longo: {vagas: 0, duracao: ''}
+    },
+    tags: []
+  })
+
+  function getStatusConfig(id: string) {
+    return statusConfig.value.find(s => s.id === id) || defaultStatusConfig[0]
+  }
+
+  async function fetchConfiguracoes() {
+    try {
+      const res = await api.get('/api/configuracoes')
+      parametros.value = res.data
+    } catch (e) {
+      console.error("Erro na API de configurações:", e)
+      throw e
+    }
+  }
+
+  async function salvarConfiguracoes(dados: ParametrosAgendamento) {
+    try {
+      const res = await api.put('/api/configuracoes', dados)
+      parametros.value = res.data
+      toast.success("Configurações salvas com sucesso")
+    } catch (e) {
+      console.error(e)
+      toast.error("Erro ao salvar configurações")
+      throw e
+    }
+  }
+
+  return {
+    statusConfig,
+    parametros,
+    getStatusConfig,
+    fetchConfiguracoes,
+    salvarConfiguracoes
+  }
+})

--- a/frontend/src/stores/paciente.ts
+++ b/frontend/src/stores/paciente.ts
@@ -1,0 +1,85 @@
+import {defineStore} from 'pinia'
+import {ref} from 'vue'
+import api from '@/services/api'
+import {toast} from 'vue-sonner'
+import type {Paciente} from '@/types'
+
+export const usePacienteStore = defineStore('paciente', () => {
+  const pacientes = ref<Paciente[]>([])
+  const totalPacientes = ref(0)
+  const resultadosBusca = ref<Paciente[]>([])
+
+  function getPacienteById(id: string) {
+    const p = pacientes.value.find(p => p.id === id)
+    if (p && !p.idade && p.dataNascimento) {
+      const nascimento = new Date(p.dataNascimento)
+      const hoje = new Date()
+      let idade = hoje.getFullYear() - nascimento.getFullYear()
+      const m = hoje.getMonth() - nascimento.getMonth()
+      if (m < 0 || (m === 0 && hoje.getDate() < nascimento.getDate())) {
+        idade--
+      }
+      p.idade = idade
+    }
+    return p
+  }
+
+  async function fetchPacientes(page = 1, size = 10, termo = '') {
+    try {
+      const params: any = {page, size}
+      if (termo) params.termo = termo
+
+      const res = await api.get('/api/pacientes', {params})
+
+      pacientes.value = res.data.items
+      totalPacientes.value = res.data.total
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async function buscarPacientesDropdown(termo: string) {
+    if (!termo || termo.length < 2) {
+      resultadosBusca.value = []
+      return
+    }
+    try {
+      const res = await api.get('/api/pacientes', {params: {termo, page: 1, size: 20}})
+      resultadosBusca.value = res.data.items
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async function adicionarPaciente(paciente: any) {
+    try {
+      const res = await api.post('/api/pacientes', paciente)
+      pacientes.value.push(res.data)
+      return res.data
+    } catch (e) {
+      throw e
+    }
+  }
+
+  async function atualizarPaciente(id: string, dados: any) {
+    try {
+      const res = await api.put(`/api/pacientes/${id}`, dados)
+      const idx = pacientes.value.findIndex(p => p.id === id)
+      if (idx !== -1) pacientes.value[idx] = res.data
+      toast.success("Dados do paciente atualizados")
+    } catch (e) {
+      toast.error("Erro ao atualizar paciente")
+    }
+  }
+
+  return {
+    pacientes,
+    totalPacientes,
+    resultadosBusca,
+    getPacienteById,
+    fetchPacientes,
+    buscarPacientesDropdown,
+    adicionarPaciente,
+    atualizarPaciente
+  }
+})

--- a/frontend/src/stores/prescricao.ts
+++ b/frontend/src/stores/prescricao.ts
@@ -1,0 +1,65 @@
+import {defineStore} from 'pinia'
+import {ref} from 'vue'
+import api from '@/services/api'
+import {toast} from 'vue-sonner'
+import type {PrescricaoMedica} from '@/types'
+import {useProtocoloStore} from './protocolo'
+
+export const usePrescricaoStore = defineStore('prescricao', () => {
+  const prescricoes = ref<PrescricaoMedica[]>([])
+
+  const protocoloStore = useProtocoloStore()
+
+  function getPrescricoesPorPaciente(pacienteId: string) {
+    return prescricoes.value.filter(p => p.pacienteId === pacienteId)
+  }
+
+  function getProtocoloPeloHistorico(pacienteId: string) {
+    const lista = prescricoes.value.filter(p => p.pacienteId === pacienteId)
+
+    if (lista.length === 0) return null
+
+    const ultima = lista.sort((a, b) =>
+      new Date(b.dataPrescricao).getTime() - new Date(a.dataPrescricao).getTime()
+    )[0]
+
+    if (ultima.protocoloId) {
+      const proto = protocoloStore.protocolos.find(p => p.id === ultima.protocoloId)
+      if (proto) return proto
+    }
+
+    if (ultima.protocolo) {
+      return {nome: ultima.protocolo} as any
+    }
+
+    return null
+  }
+
+  async function fetchPrescricoes(pacienteId: string) {
+    try {
+      const res = await api.get(`/api/prescricoes/paciente/${pacienteId}`)
+      prescricoes.value = prescricoes.value.filter(p => p.pacienteId !== pacienteId).concat(res.data)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async function adicionarPrescricao(prescricao: any) {
+    try {
+      const res = await api.post('/api/prescricoes', prescricao)
+      prescricoes.value.push(res.data)
+      return res.data
+    } catch (e) {
+      toast.error("Erro ao criar prescrição")
+      throw e
+    }
+  }
+
+  return {
+    prescricoes,
+    getPrescricoesPorPaciente,
+    getProtocoloPeloHistorico,
+    fetchPrescricoes,
+    adicionarPrescricao
+  }
+})

--- a/frontend/src/stores/protocolo.ts
+++ b/frontend/src/stores/protocolo.ts
@@ -1,0 +1,63 @@
+import {defineStore} from 'pinia'
+import {ref} from 'vue'
+import api from '@/services/api'
+import {toast} from 'vue-sonner'
+import type {Protocolo} from '@/types'
+
+export const useProtocoloStore = defineStore('protocolo', () => {
+  const protocolos = ref<Protocolo[]>([])
+
+  function getProtocoloById(id: string) {
+    return protocolos.value.find(p => p.id === id)
+  }
+
+  async function fetchProtocolos() {
+    try {
+      const res = await api.get('/api/protocolos', {params: {ativo: true}})
+      protocolos.value = res.data
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  async function adicionarProtocolo(protocolo: any) {
+    try {
+      const res = await api.post('/api/protocolos', protocolo)
+      protocolos.value.push(res.data)
+    } catch (e) {
+      toast.error("Erro ao salvar protocolo")
+      throw e
+    }
+  }
+
+  async function atualizarProtocolo(id: string, dados: any) {
+    try {
+      const res = await api.put(`/api/protocolos/${id}`, dados)
+      const idx = protocolos.value.findIndex(p => p.id === id)
+      if (idx !== -1) protocolos.value[idx] = res.data
+    } catch (e) {
+      toast.error("Erro ao atualizar protocolo")
+      throw e
+    }
+  }
+
+  async function desativarProtocolo(id: string) {
+    try {
+      await api.delete(`/api/protocolos/${id}`)
+      const idx = protocolos.value.findIndex(p => p.id === id)
+      if (idx !== -1) protocolos.value[idx].ativo = false
+    } catch (e) {
+      toast.error("Erro ao desativar")
+      throw e
+    }
+  }
+
+  return {
+    protocolos,
+    getProtocoloById,
+    fetchProtocolos,
+    adicionarProtocolo,
+    atualizarProtocolo,
+    desativarProtocolo
+  }
+})


### PR DESCRIPTION
Decompõe a store central `app.ts` em cinco novas stores menores para melhorar a manutenabilidade, facilitar a futura validação de dados com Zod e isolar domínios de negócio:

- PacienteStore: CRUD e busca de pacientes.
- AgendamentoStore: Gestão de horários, status e remarcações.
- ProtocoloStore: Catálogo de protocolos médicos.
- PrescricaoStore: Histórico e novas prescrições.
- ConfiguracaoStore: Parâmetros globais e configurações de interface.

O arquivo `app.ts` foi mantido como uma Facade (ponto central de acesso) que integra e reexporta o estado e as ações das novas stores. Esta abordagem foi escolhida para evitar a quebra de compatibilidade com os componentes existentes, permitindo uma migração gradual das referências nos arquivos .vue sem a necessidade de refatorar todo o projeto em um único passo.