### PR TITLE
fix: corrige fuso horário na inicialização de datas

### DIFF
--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -11,3 +11,11 @@ export function cn(...inputs: ClassValue[]) {
 export function valueUpdater<T extends Updater<any>>(updaterOrValue: T, ref: Ref) {
   ref.value = typeof updaterOrValue === "function" ? updaterOrValue(ref.value) : updaterOrValue
 }
+
+export function getDataLocal(): string {
+  const date = new Date()
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -5,6 +5,7 @@ import {useAgendamentoStore} from './agendamento'
 import {useConfiguracaoStore} from './configuracao'
 import {useProtocoloStore} from './protocolo'
 import {usePrescricaoStore} from './prescricao'
+import {getDataLocal} from '@/lib/utils.ts';
 
 export const useAppStore = defineStore('app', () => {
   const pacienteStore = usePacienteStore()
@@ -62,7 +63,7 @@ export const useAppStore = defineStore('app', () => {
   async function fetchInitialData() {
     try {
       await Promise.all([fetchPacientes(), fetchProtocolos(), fetchConfiguracoes()])
-      const hoje = new Date().toISOString().split('T')[0]
+      const hoje = getDataLocal()
       await fetchAgendamentos(hoje, hoje)
     } catch (error) {
       console.error("Erro ao carregar dados iniciais", error)

--- a/frontend/src/views/AgendaView.vue
+++ b/frontend/src/views/AgendaView.vue
@@ -12,11 +12,12 @@ import TagsModal from '@/components/modals/TagsModal.vue'
 import AgendaControls, {type FiltrosAgenda} from '@/components/agenda/AgendaControls.vue'
 import {calcularDuracaoMinutos, getGrupoInfusao} from '@/utils/agendaUtils'
 import {StatusPaciente} from "@/types";
+import {getDataLocal} from '@/lib/utils.ts';
 
 const router = useRouter()
 const appStore = useAppStore()
 
-const dataSelecionada = ref(new Date().toISOString().split('T')[0])
+const dataSelecionada = ref(getDataLocal())
 
 const tagsModalOpen = ref(false)
 const tagsModalData = ref<{ id: string; tags: string[] } | null>(null)

--- a/frontend/src/views/FarmaciaView.vue
+++ b/frontend/src/views/FarmaciaView.vue
@@ -5,9 +5,10 @@ import {isInfusao, type StatusFarmacia} from '@/types'
 import FarmaciaHeader from '@/components/farmacia/FarmaciaHeader.vue'
 import FarmaciaMetrics from '@/components/farmacia/FarmaciaMetrics.vue'
 import FarmaciaTable from '@/components/farmacia/FarmaciaTable.vue'
+import {getDataLocal} from '@/lib/utils.ts';
 
 const appStore = useAppStore()
-const dataSelecionada = ref(new Date().toISOString().split('T')[0])
+const dataSelecionada = ref(getDataLocal())
 
 const handleDiaAnterior = () => {
   const d = new Date(dataSelecionada.value)

--- a/frontend/src/views/RelatoriosView.vue
+++ b/frontend/src/views/RelatoriosView.vue
@@ -6,6 +6,7 @@ import RelatoriosFiltros from '@/components/relatorios/RelatoriosFiltros.vue'
 import RelatoriosFarmacia from '@/components/relatorios/RelatoriosFarmacia.vue'
 import RelatoriosFimPlantao from '@/components/relatorios/RelatoriosFimPlantao.vue'
 import RelatoriosTabela from '@/components/relatorios/RelatoriosTabela.vue'
+import {getDataLocal} from '@/lib/utils.ts';
 
 const appStore = useAppStore()
 const authStore = useAuthStore()
@@ -13,11 +14,11 @@ const authStore = useAuthStore()
 const filtros = ref({
   tipoRelatorio: authStore.user?.role === 'farmacia' ? 'medicamentos-farmacia' : 'fim-plantao',
   periodoTipo: 'dia' as 'dia' | 'mes',
-  diaSelecionado: new Date().toISOString().split('T')[0],
+  diaSelecionado: getDataLocal(),
   mesSelecionado: String(new Date().getMonth() + 1),
   anoSelecionado: String(new Date().getFullYear()),
-  dataInicio: new Date().toISOString().split('T')[0],
-  dataFim: new Date().toISOString().split('T')[0]
+  dataInicio: getDataLocal(),
+  dataFim: getDataLocal()
 })
 
 const opcoesRelatorio = computed(() => {


### PR DESCRIPTION
- Adicionada função `getDataLocal` em `utils.ts` para retornar YYYY-MM-DD no fuso local.
- Substituído o uso de `new Date().toISOString()` por `getDataLocal()` em `fetchInitialData` e nas Views de Agenda, Farmácia e Relatórios.
- Corrige bug onde o sistema pulava para o dia seguinte após as 21h (UTC-3), resultando em telas vazias.