### PR TITLE
fix: corrige grupos de infusão, filtro da farmácia na agenda e relatórios

### DIFF
--- a/frontend/src/components/agenda/AgendaControls.vue
+++ b/frontend/src/components/agenda/AgendaControls.vue
@@ -196,8 +196,8 @@ const activeCount = computed(() => {
             <DropdownMenuLabel>Grupo de Infusão</DropdownMenuLabel>
             <DropdownMenuSeparator/>
             <DropdownMenuCheckboxItem
-                :checked="filtros.gruposInfusao.includes('curto')"
-                @select.prevent="toggleFilter('gruposInfusao', 'curto')"
+                :checked="filtros.gruposInfusao.includes('rapido')"
+                @select.prevent="toggleFilter('gruposInfusao', 'rapido')"
             >
               <span class="w-2 h-2 rounded-full bg-emerald-500 mr-2"></span> Rápida (&lt;2h)
             </DropdownMenuCheckboxItem>

--- a/frontend/src/components/agenda/AgendaMetrics.vue
+++ b/frontend/src/components/agenda/AgendaMetrics.vue
@@ -10,7 +10,7 @@ defineProps<{
     tarde: number
     emAndamento: number
     concluidos: number
-    curto: number
+    rapido: number
     medio: number
     longo: number
     intercorrencias: number
@@ -64,7 +64,7 @@ defineProps<{
       <CardContent class="space-y-4">
         <div class="grid grid-cols-3 gap-2 text-center text-sm">
           <div class="bg-green-50 p-2 rounded border border-green-100">
-            <span class="text-2xl block font-bold text-green-700">{{ metricas.curto }}</span>
+            <span class="text-2xl block font-bold text-green-700">{{ metricas.rapido }}</span>
             <span class="text-xs text-green-500">Curta</span>
           </div>
           <div class="bg-amber-50 p-2 rounded border border-amber-100">

--- a/frontend/src/components/agenda/AgendaTable.vue
+++ b/frontend/src/components/agenda/AgendaTable.vue
@@ -8,7 +8,7 @@ import {Button} from '@/components/ui/button'
 import {AlertTriangle, ChevronDown, Clock, Tag} from 'lucide-vue-next'
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip'
 import {type Agendamento, isInfusao} from '@/types'
-import {calcularDuracaoMinutos, formatarDuracao, getBadgeGrupo, getCorGrupo, getGrupoInfusao} from '@/utils/agendaUtils'
+import {formatarDuracao, getBadgeGrupo, getCorGrupo, getDuracaoAgendamento, getGrupoInfusao} from '@/utils/agendaUtils'
 
 defineProps<{
   agendamentos: Agendamento[]
@@ -53,13 +53,13 @@ const getStatusDotColor = (statusId: string) => {
 }
 
 const getAgendamentoInfo = (ag: Agendamento) => {
-  const duracaoMin = calcularDuracaoMinutos(ag.horarioInicio, ag.horarioFim)
+  const duracaoMin = getDuracaoAgendamento(ag, appStore)
   const grupo = getGrupoInfusao(duracaoMin)
   return {
     duracaoTexto: formatarDuracao(duracaoMin),
     corBorda: getCorGrupo(grupo),
     corBadge: getBadgeGrupo(grupo),
-    grupoLabel: grupo === 'curto' ? 'Rápida' : grupo === 'medio' ? 'Média' : 'Longa'
+    grupoLabel: grupo === 'rapido' ? 'Rápida' : grupo === 'medio' ? 'Média' : 'Longa'
   }
 }
 

--- a/frontend/src/utils/agendaUtils.ts
+++ b/frontend/src/utils/agendaUtils.ts
@@ -1,6 +1,8 @@
-export type GrupoInfusao = 'curto' | 'medio' | 'longo' | 'indefinido'
+import {Agendamento} from '@/types';
 
-export const LIMITE_CURTO_MINUTOS = 119
+export type GrupoInfusao = 'rapido' | 'medio' | 'longo' | 'indefinido'
+
+export const LIMITE_RAPIDO_MINUTOS = 119
 export const LIMITE_MEDIO_MINUTOS = 239
 
 export function calcularDuracaoMinutos(inicio: string, fim: string): number {
@@ -19,16 +21,24 @@ export function formatarDuracao(minutos: number): string {
   return `${m}m`
 }
 
+export function getDuracaoAgendamento(ag: Agendamento, store: any): number {
+  const protocolo = store.getProtocoloPeloHistorico(ag.pacienteId)
+  if (protocolo && protocolo.duracao) {
+    return protocolo.duracao
+  }
+  return calcularDuracaoMinutos(ag.horarioInicio, ag.horarioFim)
+}
+
 export function getGrupoInfusao(minutos: number): GrupoInfusao {
   if (minutos <= 0) return 'indefinido'
-  if (minutos <= LIMITE_CURTO_MINUTOS) return 'curto'
+  if (minutos <= LIMITE_RAPIDO_MINUTOS) return 'rapido'
   if (minutos <= LIMITE_MEDIO_MINUTOS) return 'medio'
   return 'longo'
 }
 
 export function getCorGrupo(grupo: GrupoInfusao): string {
   switch (grupo) {
-    case 'curto': return 'bg-emerald-500'
+    case 'rapido': return 'bg-emerald-500'
     case 'medio': return 'bg-amber-500'
     case 'longo': return 'bg-rose-600'
     default: return 'bg-gray-200'
@@ -37,7 +47,7 @@ export function getCorGrupo(grupo: GrupoInfusao): string {
 
 export function getBadgeGrupo(grupo: GrupoInfusao): string {
   switch (grupo) {
-    case 'curto': return 'text-emerald-700 bg-emerald-50 border-emerald-100'
+    case 'rapido': return 'text-emerald-700 bg-emerald-50 border-emerald-100'
     case 'medio': return 'text-amber-700 bg-amber-50 border-amber-100'
     case 'longo': return 'text-rose-700 bg-rose-50 border-rose-100'
     default: return 'text-gray-500 bg-gray-50 border-gray-100'


### PR DESCRIPTION
Agenda e Métricas:
- Padroniza a nomenclatura de grupos de infusão ('curto' -> 'rapido') em todo o frontend para consistência com os tipos.
- Centraliza a lógica de cálculo de duração em `agendaUtils`: agora prioriza a duração definida no protocolo do paciente; usa o horário agendado apenas como fallback. Isso corrige a exibição incorreta de agendamentos manuais com duração zerada.
- Atualiza os filtros e métricas da Agenda para acessar corretamente o `status_farmacia` dentro do objeto `detalhes.infusao`, corrigindo a regressão onde os status não eram contabilizados após a mudança de estrutura de dados.

Relatórios:
- Corrige a inferência de protocolos: substitui a busca por campo estático (inexistente) pelo método `getProtocoloPeloHistorico` baseado nas prescrições.
- Implementa watcher para recarregar dados (agendamentos e prescrições) ao alterar filtros.
- Ajusta a formatação de data para evitar discrepâncias de fuso horário (UTC vs Local).

Tech Note:
- O componente `AgendaTable` ainda retém responsabilidades de lógica de negócio. Futuramente, este deve ser refatorado para um componente puramente apresentacional para garantir melhor separação de responsabilidades.