### PR TITLE
fix: resolve problema onde o histórico de agendamentos do paciente não carregava

### DIFF
--- a/frontend/src/views/PacientesView.vue
+++ b/frontend/src/views/PacientesView.vue
@@ -85,7 +85,7 @@ const carregarPacienteDaUrl = async () => {
       dadosEditados.value = JSON.parse(JSON.stringify(p))
       await Promise.all([
         appStore.fetchPrescricoes(pid),
-        appStore.fetchAgendamentos(pid)
+        appStore.fetchAgendamentos()
       ])
     }
   } else {


### PR DESCRIPTION
A função fetchAgendamentos estava sendo erroneamente chamada com o id do paciente. O parâmetro foi removido, para que a função retorne todos os agendamentos.