### PR TITLE
fix: corrige estrutura do payload para suspensão e intercorrência na agenda

### DIFF
--- a/frontend/src/components/agenda/AgendaStatusChangeModal.vue
+++ b/frontend/src/components/agenda/AgendaStatusChangeModal.vue
@@ -82,24 +82,20 @@ const handleConfirm = () => {
   const payloadDetalhes: any = {}
 
   if (isSuspensao.value) {
-    payloadDetalhes.tipo = 'suspensao'
-    payloadDetalhes.motivo = motivoSuspensao.value
-
-    if (motivoSuspensao.value === 'medicacao_falta') {
-      payloadDetalhes.medicamento = medicamentoFalta.value
-    }
+    payloadDetalhes.suspensao = {}
+    payloadDetalhes.suspensao.motivo_suspensao = motivoSuspensao.value
+    if (motivoSuspensao.value === 'medicacao_falta')
+      payloadDetalhes.suspensao.medicamento_falta = medicamentoFalta.value
+    if (observacaoLivre.value)
+      payloadDetalhes.suspensao.observacoes = observacaoLivre.value
   } else if (isIntercorrencia.value) {
-    payloadDetalhes.tipo = 'intercorrencia'
-    payloadDetalhes.subtipo = tipoIntercorrencia.value
-    payloadDetalhes.medicamento = medicamentoIntercorrencia.value
-
-    if (tipoIntercorrencia.value === 'hipersensibilidade') {
-      payloadDetalhes.vigihosp = vigihospFeito.value
-    }
-  }
-
-  if (observacaoLivre.value) {
-    payloadDetalhes.texto_adicional = observacaoLivre.value
+    payloadDetalhes.intercorrencia = {}
+    payloadDetalhes.intercorrencia.tipo_intercorrencia = tipoIntercorrencia.value
+    payloadDetalhes.intercorrencia.medicamento_intercorrencia = medicamentoIntercorrencia.value
+    if (tipoIntercorrencia.value === 'hipersensibilidade')
+      payloadDetalhes.intercorrencia.vigihosp = vigihospFeito.value
+    if (observacaoLivre.value)
+      payloadDetalhes.intercorrencia.observacoes = observacaoLivre.value
   }
 
   emit('confirm', payloadDetalhes)

--- a/src/schemas/agendamento.py
+++ b/src/schemas/agendamento.py
@@ -65,11 +65,14 @@ class DetalhesConsulta(BaseModel):
 class DetalhesIntercorrencia(BaseModel):
     tipo_intercorrencia: TipoIntercorrencia
     medicamento_intercorrencia: str
+    vigihosp: Optional[bool] = None
+    observacoes: Optional[str] = None
 
 
 class DetalhesSuspensao(BaseModel):
     motivo_suspensao: MotivoSuspensao
     medicamento_falta: Optional[str] = None
+    observacoes: Optional[str] = None
 
 
 class DetalhesCancelamento(BaseModel):


### PR DESCRIPTION
- Adiciona campos faltantes no schema Pydantic (vigihosp e observações).
- Alinha nomes de campos (ex: tipo_intercorrencia) com o schema Pydantic.
- Ajusta o envio de dados para respeitar a estrutura aninhada esperado pelo backend.