### PR TITLE
fix: corrige carregamento do prontuário via URL e cache local

### DIFF
--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -29,6 +29,7 @@ export const useAppStore = defineStore('app', () => {
   const {
     getPacienteById,
     fetchPacientes,
+    carregarPaciente,
     buscarPacientesDropdown,
     adicionarPaciente,
     atualizarPaciente
@@ -94,6 +95,7 @@ export const useAppStore = defineStore('app', () => {
     fetchConfiguracoes,
     salvarConfiguracoes,
     fetchPacientes,
+    carregarPaciente,
     buscarPacientesDropdown,
     fetchAgendamentos,
     fetchPrescricoes,

--- a/frontend/src/stores/paciente.ts
+++ b/frontend/src/stores/paciente.ts
@@ -38,6 +38,24 @@ export const usePacienteStore = defineStore('paciente', () => {
     }
   }
 
+  async function carregarPaciente(id: string) {
+    let p = getPacienteById(id)
+    if (p) return p
+
+    try {
+      const pacienteEncontrado = (await api.get(`/api/pacientes/${id}`)).data
+
+      if (pacienteEncontrado) {
+        const existe = pacientes.value.some(x => x.id == pacienteEncontrado.id)
+        if (!existe) pacientes.value.push(pacienteEncontrado)
+        return pacienteEncontrado
+      }
+    } catch (e) {
+      console.error("Erro ao carregar paciente.", e)
+      return null
+    }
+  }
+
   async function buscarPacientesDropdown(termo: string) {
     if (!termo || termo.length < 2) {
       resultadosBusca.value = []
@@ -78,6 +96,7 @@ export const usePacienteStore = defineStore('paciente', () => {
     resultadosBusca,
     getPacienteById,
     fetchPacientes,
+    carregarPaciente,
     buscarPacientesDropdown,
     adicionarPaciente,
     atualizarPaciente

--- a/frontend/src/views/PacientesView.vue
+++ b/frontend/src/views/PacientesView.vue
@@ -79,7 +79,7 @@ const ultimoAgendamento = computed(() => {
 const carregarPacienteDaUrl = async () => {
   if (route.query.pacienteId) {
     const pid = route.query.pacienteId as string
-    const p = appStore.getPacienteById(pid)
+    const p = await appStore.carregarPaciente(pid)
     if (p) {
       pacienteSelecionado.value = p
       dadosEditados.value = JSON.parse(JSON.stringify(p))
@@ -107,8 +107,12 @@ watch([page, termoBusca], () => {
   carregarDadosPagina()
 }, {immediate: true})
 
-watch(() => route.query.pacienteId, () => {
-  carregarPacienteDaUrl()
+watch(() => route.query.pacienteId, (newId) => {
+  if (newId) {
+    carregarPacienteDaUrl()
+  } else {
+    pacienteSelecionado.value = null
+  }
 })
 
 const handleSelecionarPaciente = (paciente: Paciente) => {


### PR DESCRIPTION
- Implementa a função `carregarPaciente` na store para buscar dados na API caso o paciente não esteja no cache local, devido à paginação da lista de pacientes.
- Ajusta o componente `PacientesView` para monitorar corretamente alterações na query `pacienteId`, limpando a seleção quando o parâmetro é removido.