### PR TITLE
feature: adiciona gerenciamento de diluentes e importação via CSV

### DIFF
--- a/frontend/src/components/Layout.vue
+++ b/frontend/src/components/Layout.vue
@@ -5,9 +5,11 @@ import {useAuthStore} from '@/stores/auth'
 import {useMediaQuery} from '@vueuse/core'
 import {Calendar, FileText, LogOut, Menu, Pill, Settings, Stethoscope, Users, X} from 'lucide-vue-next'
 import {Button} from '@/components/ui/button'
+import {useConfiguracaoStore} from "@/stores/configuracao.ts";
 
 const router = useRouter()
 const authStore = useAuthStore()
+const configStore = useConfiguracaoStore()
 
 const isDesktop = useMediaQuery('(min-width: 1024px)')
 
@@ -15,6 +17,7 @@ const sidebarOpen = ref(true)
 
 onMounted(async () => {
   sidebarOpen.value = window.innerWidth >= 1024
+  await configStore.fetchConfiguracoes()
 })
 
 watch(isDesktop, (ehDesktop) => {

--- a/frontend/src/components/ajustes/AjustesDiluentes.vue
+++ b/frontend/src/components/ajustes/AjustesDiluentes.vue
@@ -1,0 +1,100 @@
+<script lang="ts" setup>
+import {ref} from 'vue'
+import {Card, CardContent, CardDescription, CardHeader, CardTitle} from '@/components/ui/card'
+import {Label} from '@/components/ui/label'
+import {Input} from '@/components/ui/input'
+import {Button} from '@/components/ui/button'
+import {toast} from 'vue-sonner'
+import {Trash, Upload} from 'lucide-vue-next'
+
+const props = defineProps<{
+  diluentes: string[]
+}>()
+
+const emit = defineEmits(['update:diluentes'])
+const novoDiluente = ref('')
+
+const handleAdicionar = () => {
+  const val = novoDiluente.value.trim()
+  if (val && !props.diluentes.includes(val)) {
+    const novaLista = [...props.diluentes, val].sort((a, b) => a.localeCompare(b))
+    emit('update:diluentes', novaLista)
+    novoDiluente.value = ''
+  }
+}
+
+const handleRemover = (item: string) => {
+  emit('update:diluentes', props.diluentes.filter(d => d !== item))
+}
+
+const handleImportarCsv = (event: Event) => {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file) return
+
+  const reader = new FileReader()
+  reader.onload = (e) => {
+    const text = e.target?.result as string
+    if (!text) return
+    const linhas = text.split(/\r\n|\n/).map(l => l.trim()).filter(l => l.length > 0)
+
+    const listaAtualizada = [...props.diluentes]
+    let adicionados = 0
+
+    linhas.forEach(linha => {
+      if (!listaAtualizada.includes(linha)) {
+        listaAtualizada.push(linha)
+        adicionados++
+      }
+    })
+
+    listaAtualizada.sort((a, b) => a.localeCompare(b))
+    emit('update:diluentes', listaAtualizada)
+    toast.success(`${adicionados} diluentes importados com sucesso.`)
+    ;(event.target as HTMLInputElement).value = ''
+  }
+  reader.readAsText(file)
+}
+</script>
+
+<template>
+  <Card>
+    <CardHeader>
+      <div class="flex items-center justify-between">
+        <div>
+          <CardTitle>Opções de Diluição</CardTitle>
+          <CardDescription>Gerencie a lista de diluentes disponíveis para protocolos.</CardDescription>
+        </div>
+        <div>
+          <Label class="cursor-pointer" for="csv-upload">
+            <div
+                class="flex items-center gap-2 text-sm bg-slate-100 hover:bg-slate-200 px-3 py-2 rounded-md transition-colors">
+              <Upload class="h-4 w-4"/>
+              Importar CSV
+            </div>
+          </Label>
+          <input id="csv-upload" accept=".csv,.txt" class="hidden" type="file" @change="handleImportarCsv"/>
+        </div>
+      </div>
+    </CardHeader>
+    <CardContent class="space-y-4">
+      <div class="flex gap-2">
+        <Input v-model="novoDiluente" placeholder="Ex: Soro Fisiológico 0,9% 100ml" @keyup.enter="handleAdicionar"/>
+        <Button variant="secondary" @click="handleAdicionar">Adicionar</Button>
+      </div>
+
+      <div class="border rounded-md divide-y">
+        <div v-if="diluentes.length === 0" class="p-4 text-center text-muted-foreground text-sm">
+          Nenhum diluente cadastrado.
+        </div>
+        <div v-for="item in diluentes" :key="item"
+             class="flex items-center justify-between px-3 py-1 hover:bg-slate-50 text-sm">
+          <span>{{ item }}</span>
+          <Button class="h-8 w-8 text-red-500 hover:bg-red-50 hover:text-red-500" size="icon" variant="ghost"
+                  @click="handleRemover(item)">
+            <Trash class="h-4 w-4"/>
+          </Button>
+        </div>
+      </div>
+    </CardContent>
+  </Card>
+</template>

--- a/frontend/src/components/modals/PrescricaoHistoricoModal.vue
+++ b/frontend/src/components/modals/PrescricaoHistoricoModal.vue
@@ -138,7 +138,7 @@ const handleBaixar = async () => {
             </div>
             <div class="flex flex-col">
               <span class="text-sm text-gray-500">Creatinina</span>
-              <span class="font-medium">{{ prescricao.conteudo.paciente.creatinina || '-' }}</span>
+              <span class="font-medium">{{ prescricao.conteudo.paciente.creatinina ? prescricao.conteudo.paciente.creatinina + ' mg/dL' : '-' }}</span>
             </div>
           </div>
         </div>

--- a/frontend/src/components/prescricao/PrescricaoItemRow.vue
+++ b/frontend/src/components/prescricao/PrescricaoItemRow.vue
@@ -6,6 +6,7 @@ import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/c
 import {AlertTriangle} from 'lucide-vue-next'
 import {UnidadeDoseEnum} from "@/types"
 import {formatDiasCiclo, getUnidadeFinal} from "@/utils/prescricaoUtils.ts";
+import {useAppStore} from "@/stores/app.ts";
 
 const props = defineProps<{
   item: any
@@ -19,6 +20,8 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits(['update:item'])
+
+const appStore = useAppStore()
 
 const doseCalculadaInicial = computed(() => {
   const ref = parseFloat(props.item.doseReferencia) || 0
@@ -81,6 +84,10 @@ const formatNumber = (val: number) => {
     minimumFractionDigits: casasDecimais,
     maximumFractionDigits: casasDecimais
   });
+}
+
+const isDiluenteDisponivel = (nome: string) => {
+  return !appStore.parametros.diluentes?.includes(nome)
 }
 </script>
 
@@ -201,8 +208,11 @@ const formatNumber = (val: number) => {
             v-model="item.diluicaoFinal"
             :disabled="!diluentesPermitidos || diluentesPermitidos.length === 0"
         >
-          <SelectTrigger class="h-8 text-sm">
-            <SelectValue :placeholder="(!diluentesPermitidos || diluentesPermitidos.length === 0) ? 'Sem diluentes' : 'Selecione...'"/>
+          <SelectTrigger
+              :class="diluentesPermitidos.length > 0 && isDiluenteDisponivel(item.diluicaoFinal) ? 'border-red-300 bg-red-50 text-red-900' : ''"
+              class="h-8 text-sm"
+          >
+            <SelectValue :placeholder="(!diluentesPermitidos || diluentesPermitidos.length === 0) ? 'Sem opções' : 'Selecione...'"/>
           </SelectTrigger>
           <SelectContent>
             <SelectItem
@@ -210,7 +220,15 @@ const formatNumber = (val: number) => {
                 :key="dil"
                 :value="dil"
             >
-              {{ dil }}
+              <span :class="isDiluenteDisponivel(dil) ? 'text-red-600 line-through decoration-red-600/50' : ''">
+                {{ dil }}
+              </span>
+              <span
+                  v-if="isDiluenteDisponivel(dil)"
+                  class="text-[10px] text-red-500 font-bold bg-red-50 px-1 rounded ml-auto"
+              >
+                INDISPONÍVEL
+              </span>
             </SelectItem>
           </SelectContent>
         </Select>

--- a/frontend/src/components/protocolos/ProtocolosDiluenteSelector.vue
+++ b/frontend/src/components/protocolos/ProtocolosDiluenteSelector.vue
@@ -10,26 +10,51 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import {ChevronDown} from 'lucide-vue-next'
-import {diluentesDisponiveis} from '@/utils/protocoloConstants'
-import {ConfiguracaoDiluicao} from "@/types";
+import {ConfiguracaoDiluicao} from "@/types"
+import {useConfiguracaoStore} from "@/stores/configuracao.ts"
 
 const props = defineProps<{
-  modelValue: ConfiguracaoDiluicao
+  modelValue: ConfiguracaoDiluicao | undefined
 }>()
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: ConfiguracaoDiluicao): void
 }>()
 
+const configStore = useConfiguracaoStore()
+
+const listaGlobalDiluentes = computed(() => {
+  return configStore.parametros?.diluentes || []
+})
+
+const safeModelValue = computed((): ConfiguracaoDiluicao => {
+  return props.modelValue || { selecionada: '', opcoesPermitidas: [] }
+})
+
+const diluentesUnificados = computed(() => {
+  const globais = listaGlobalDiluentes.value
+  const locais = safeModelValue.value.opcoesPermitidas || []
+  const unicos = new Set([...globais, ...locais])
+  return Array.from(unicos).sort((a, b) => a.localeCompare(b))
+})
+
+const isIndisponivel = (diluente: string) => {
+  if (listaGlobalDiluentes.value.length === 0) return false
+  return !listaGlobalDiluentes.value.includes(diluente)
+}
+
 const labelResumido = computed(() => {
-  const permitidos = props.modelValue?.opcoesPermitidas || []
+  if (diluentesUnificados.value.length === 0) return 'Sem opções'
+  const permitidos = safeModelValue.value.opcoesPermitidas || []
   if (permitidos.length === 0) return 'Selecione...'
   if (permitidos.length === 1) return permitidos[0]
   return `${permitidos.length} selecionados`
 })
 
 const toggleDiluente = (diluente: string, checked: boolean) => {
-  const novoConfig = {...props.modelValue}
+  const novoConfig: ConfiguracaoDiluicao = props.modelValue
+    ? {...props.modelValue}
+    : { selecionada: '', opcoesPermitidas: [] }
 
   if (!novoConfig.opcoesPermitidas) novoConfig.opcoesPermitidas = []
 
@@ -48,6 +73,13 @@ const toggleDiluente = (diluente: string, checked: boolean) => {
   }
   emit('update:modelValue', novoConfig)
 }
+
+const updateSelecionada = (val: string) => {
+  const novoConfig: ConfiguracaoDiluicao = props.modelValue
+      ? {...props.modelValue, selecionada: val}
+      : {selecionada: val, opcoesPermitidas: [val]}
+  emit('update:modelValue', novoConfig)
+}
 </script>
 
 <template>
@@ -56,20 +88,33 @@ const toggleDiluente = (diluente: string, checked: boolean) => {
       <Label class="text-sm">Diluentes Permitidos</Label>
       <DropdownMenu>
         <DropdownMenuTrigger as-child>
-          <Button class="w-full justify-between font-normal px-2 bg-white h-8 text-sm" variant="outline">
+          <Button
+            class="w-full justify-between font-normal px-2 bg-white h-8 text-sm"
+            variant="outline"
+            :disabled="diluentesUnificados.length === 0"
+          >
             <span class="truncate">{{ labelResumido }}</span>
             <ChevronDown class="h-3 w-3 opacity-50"/>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" class="text-sm w-full max-h-60 overflow-y-auto">
+          <div v-if="diluentesUnificados.length === 0" class="p-2 text-xs text-muted-foreground text-center">
+            Nenhum diluente cadastrado
+          </div>
+
           <DropdownMenuCheckboxItem
-              v-for="dil in diluentesDisponiveis"
+              v-for="dil in diluentesUnificados"
               :key="dil"
-              :checked="modelValue.opcoesPermitidas?.includes(dil)"
-              class="hover:bg-neutral-100"
-              @select.prevent="toggleDiluente(dil, !modelValue.opcoesPermitidas?.includes(dil))"
+              :checked="safeModelValue.opcoesPermitidas?.includes(dil)"
+              class="hover:bg-neutral-100 flex items-center justify-between gap-2"
+              @select.prevent="toggleDiluente(dil, !safeModelValue.opcoesPermitidas?.includes(dil))"
           >
-            {{ dil }}
+            <span :class="isIndisponivel(dil) ? 'text-red-600 line-through decoration-red-600/50' : ''">
+              {{ dil }}
+            </span>
+            <span v-if="isIndisponivel(dil)" class="text-[10px] text-red-500 font-bold bg-red-50 px-1 rounded ml-auto">
+              INDISPONÍVEL
+            </span>
           </DropdownMenuCheckboxItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -78,16 +123,26 @@ const toggleDiluente = (diluente: string, checked: boolean) => {
     <div class="col-span-6">
       <Label class="text-sm">Diluente Padrão</Label>
       <Select
-          :disabled="!modelValue.opcoesPermitidas?.length"
-          :model-value="modelValue.selecionada"
-          @update:model-value="(val) => emit('update:modelValue', { ...modelValue, selecionada: val as string})"
+          :disabled="!safeModelValue.opcoesPermitidas?.length"
+          :model-value="safeModelValue.selecionada"
+          @update:model-value="(val) => updateSelecionada(val as string)"
       >
         <SelectTrigger class="bg-white h-8 text-sm">
-          <SelectValue placeholder="Padrão"/>
+          <SelectValue :placeholder="safeModelValue.opcoesPermitidas?.length === 0 ? 'Sem opções' : 'Selecione...'"/>
         </SelectTrigger>
         <SelectContent>
-          <SelectItem v-for="d in modelValue.opcoesPermitidas || []" :key="d" :value="d" class="text-sm">
-            {{ d }}
+          <SelectItem
+            v-for="d in safeModelValue.opcoesPermitidas || []"
+            :key="d"
+            :value="d"
+            class="text-sm hover:bg-neutral-100 flex items-center justify-between gap-2"
+          >
+            <span :class="isIndisponivel(d) ? 'text-red-600 line-through decoration-red-600/50' : ''">
+              {{ d }}
+            </span>
+            <span v-if="isIndisponivel(d)" class="text-[10px] text-red-500 font-bold bg-red-50 px-1 rounded ml-auto">
+              INDISPONÍVEL
+            </span>
           </SelectItem>
         </SelectContent>
       </Select>

--- a/frontend/src/components/protocolos/ProtocolosMedicamentoEdit.vue
+++ b/frontend/src/components/protocolos/ProtocolosMedicamentoEdit.vue
@@ -15,9 +15,17 @@ const emit = defineEmits<{
   (e: 'update:modelValue', value: DetalhesMedicamento): void
 }>()
 
-const updateDias = (val: string) => {
-  const dias = val.split(',').map(s => parseInt(s.trim())).filter(n => !isNaN(n))
-  emit('update:modelValue', {...props.modelValue, diasDoCiclo: dias})
+const updateField = (field: keyof DetalhesMedicamento, value: any) => {
+  emit('update:modelValue', {
+    ...props.modelValue,
+    [field]: value
+  })
+}
+
+const updateDias = (val: string | number) => {
+  const strVal = String(val)
+  const dias = strVal.split(',').map(s => parseInt(s.trim())).filter(n => !isNaN(n))
+  updateField('diasDoCiclo', dias)
 }
 
 const formattedDias = (arr: number[]) => arr?.join(', ') || ''
@@ -82,7 +90,6 @@ const formattedDias = (arr: number[]) => arr?.join(', ') || ''
 
       <div class="col-span-8">
         <DiluenteSelector
-            v-if="modelValue.configuracaoDiluicao"
             v-model="modelValue.configuracaoDiluicao"
         />
       </div>

--- a/frontend/src/components/protocolos/ProtocolosMedicamentoRead.vue
+++ b/frontend/src/components/protocolos/ProtocolosMedicamentoRead.vue
@@ -3,11 +3,18 @@ import {Badge} from '@/components/ui/badge'
 import {HoverCard, HoverCardContent, HoverCardTrigger} from '@/components/ui/hover-card'
 import {formatDiasCiclo, getUnidadeFinal} from "@/utils/prescricaoUtils.ts"
 import {DetalhesMedicamento} from "@/types";
+import {useAppStore} from "@/stores/app.ts";
 
 defineProps<{
   dados: DetalhesMedicamento
 }>()
 
+const appStore = useAppStore()
+
+const isValido = (nome: string | undefined) => {
+  if (!nome) return false
+  return appStore.parametros.diluentes?.includes(nome)
+}
 </script>
 
 <template>
@@ -31,25 +38,38 @@ defineProps<{
     <div v-if="dados.configuracaoDiluicao"
          class="flex items-center gap-2 text-sm border-t border-gray-200 pt-2 mt-2">
       <span class="text-gray-500">Diluente:</span>
-      <span :title="dados.configuracaoDiluicao?.selecionada"
-            class="font-medium text-gray-700 truncate max-w-[200px]">
+      <span
+          :class="isValido(dados.configuracaoDiluicao?.selecionada) ? 'text-gray-700' : 'text-red-600'"
+          :title="dados.configuracaoDiluicao?.selecionada"
+          class="font-medium truncate flex items-center gap-1"
+      >
         {{ dados.configuracaoDiluicao?.selecionada || 'Não especificado' }}
+        <span
+            v-if="dados.configuracaoDiluicao?.selecionada && !isValido(dados.configuracaoDiluicao?.selecionada)"
+            class="text-[10px] text-red-500 font-bold bg-red-50 px-1 rounded ml-auto"
+        >
+          INDISPONÍVEL
+        </span>
       </span>
 
-      <HoverCard v-if="dados.configuracaoDiluicao?.opcoesPermitidas?.length > 1">
+      <HoverCard v-if="dados.configuracaoDiluicao?.opcoesPermitidas && dados.configuracaoDiluicao?.opcoesPermitidas?.length > 1">
         <HoverCardTrigger as-child>
           <Badge class="cursor-pointer h-5 px-1.5" variant="outline">
             +{{ dados.configuracaoDiluicao.opcoesPermitidas.length - 1 }} opções
           </Badge>
         </HoverCardTrigger>
-        <HoverCardContent class="w-64 p-3">
+        <HoverCardContent class="min-w-[16rem] w-auto p-3">
           <div class="space-y-2">
             <h4 class="text-xs font-semibold text-gray-500 uppercase">Diluentes Permitidos</h4>
             <ul class="list-disc list-inside text-xs space-y-1 text-gray-700">
-              <li v-for="dil in dados.configuracaoDiluicao.opcoesPermitidas" :key="dil">
+              <li v-for="dil in dados.configuracaoDiluicao.opcoesPermitidas" :key="dil"
+                  :class="!isValido(dil) ? 'text-red-500 line-through' : ''">
                 {{ dil }}
                 <span v-if="dil === dados.configuracaoDiluicao.selecionada" class="text-blue-500 font-bold">
                   (Padrão)
+                </span>
+                <span v-if="!isValido(dil)" class="text-[10px] text-red-500 font-bold bg-red-50 px-1 rounded ml-auto">
+                  INDISPONÍVEL
                 </span>
               </li>
             </ul>

--- a/frontend/src/stores/configuracao.ts
+++ b/frontend/src/stores/configuracao.ts
@@ -110,7 +110,8 @@ export const useConfiguracaoStore = defineStore('configuracao', () => {
     },
     tags: [],
     cargos: [],
-    funcoes: []
+    funcoes: [],
+    diluentes: [],
   })
 
   function getStatusConfig(id: string) {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -338,6 +338,7 @@ export interface ParametrosAgendamento {
   tags: string[];
   cargos: string[];
   funcoes: string[];
+  diluentes: string[];
 }
 
 export interface ConfigStatus {

--- a/frontend/src/utils/protocoloConstants.ts
+++ b/frontend/src/utils/protocoloConstants.ts
@@ -15,18 +15,3 @@ export const categoriasBloco = [
   {value: CategoriaBlocoEnum.POS_MED_DOMICILIAR, label: 'Pós-Med (Domiciliar)'},
   {value: CategoriaBlocoEnum.INFUSOR, label: 'Infusor'}
 ]
-
-export const diluentesDisponiveis = [
-  "Soro Fisiológico 0,9% 50ml",
-  "Soro Fisiológico 0,9% 100ml",
-  "Soro Fisiológico 0,9% 250ml",
-  "Soro Fisiológico 0,9% 500ml",
-  "Soro Fisiológico 0,9% 1000ml",
-  "Glicose 5% 50ml",
-  "Glicose 5% 100ml",
-  "Glicose 5% 250ml",
-  "Glicose 5% 500ml",
-  "Glicose 5% 1000ml",
-  "Água para Injeção 10ml",
-  "Sem Diluente (Bolus)"
-]

--- a/frontend/src/views/AjustesView.vue
+++ b/frontend/src/views/AjustesView.vue
@@ -14,6 +14,7 @@ import AjustesCargos from '@/components/ajustes/AjustesCargos.vue'
 import AjustesFuncoes from '@/components/ajustes/AjustesFuncoes.vue'
 import ProtocolosLista from '@/components/protocolos/ProtocolosLista.vue'
 import ProtocolosDetalhes from '@/components/protocolos/ProtocolosDetalhes.vue'
+import AjustesDiluentes from "@/components/ajustes/AjustesDiluentes.vue";
 
 const appStore = useAppStore()
 const router = useRouter()
@@ -29,6 +30,7 @@ const diasSelecionados = ref<number[]>([])
 const tags = ref<string[]>([])
 const cargos = ref<string[]>([])
 const funcoes = ref<string[]>([])
+const diluentes = ref<string[]>([])
 
 const grupos = reactive({
   rapido: {vagas: 0 as number | string, duracao: ''},
@@ -79,7 +81,8 @@ const handleSalvar = async () => {
     },
     tags: [...tags.value],
     cargos: [...cargos.value],
-    funcoes: [...funcoes.value]
+    funcoes: [...funcoes.value],
+    diluentes: [...diluentes.value]
   }
   try {
     await appStore.salvarConfiguracoes(payload)
@@ -100,6 +103,7 @@ const handleDesfazer = async () => {
     tags.value = [...(dadosSalvos.tags || [])]
     cargos.value = [...(dadosSalvos.cargos || [])]
     funcoes.value = [...(dadosSalvos.funcoes || [])]
+    diluentes.value = [...(dadosSalvos.diluentes || [])]
     Object.assign(grupos.rapido, dadosSalvos.gruposInfusao.rapido)
     Object.assign(grupos.medio, dadosSalvos.gruposInfusao.medio)
     Object.assign(grupos.longo, dadosSalvos.gruposInfusao.longo)
@@ -155,7 +159,7 @@ onMounted(async () => {
 })
 
 watch(
-    [horarioAbertura, horarioFechamento, diasSelecionados, tags, cargos, funcoes, grupos],
+    [horarioAbertura, horarioFechamento, diasSelecionados, tags, cargos, funcoes, grupos, diluentes],
     () => {
       if (!carregando.value) {
         isDirty.value = true
@@ -174,6 +178,7 @@ watch(
         tags.value = [...(newVal.tags || [])]
         cargos.value = [...(newVal.cargos || [])]
         funcoes.value = [...(newVal.funcoes || [])]
+        diluentes.value = [...(newVal.diluentes || [])]
         Object.assign(grupos.rapido, newVal.gruposInfusao.rapido)
         Object.assign(grupos.medio, newVal.gruposInfusao.medio)
         Object.assign(grupos.longo, newVal.gruposInfusao.longo)
@@ -223,7 +228,7 @@ watch(
       <TabsList>
         <TabsTrigger value="administrativo">Administrativo</TabsTrigger>
         <TabsTrigger value="vagas">Vagas</TabsTrigger>
-        <TabsTrigger value="prescricoes">Prescrições</TabsTrigger>
+        <TabsTrigger value="diluicao">Diluição</TabsTrigger>
         <TabsTrigger value="protocolos">Protocolos</TabsTrigger>
       </TabsList>
 
@@ -263,10 +268,10 @@ watch(
         />
       </TabsContent>
 
-      <TabsContent class="space-y-8 mt-6" value="prescricoes">
-        <div class="p-4 border rounded-lg bg-gray-50 text-gray-500 text-center">
-          Configurações de fórmulas e diluentes estarão disponíveis em breve.
-        </div>
+      <TabsContent class="space-y-8 mt-6" value="diluicao">
+        <AjustesDiluentes
+            v-model:diluentes="diluentes"
+        />
       </TabsContent>
     </Tabs>
 

--- a/src/models/configuracao.py
+++ b/src/models/configuracao.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, JSON
+from sqlalchemy import Column, Integer, String, JSON, Float
 
 from src.resources.database import Base
 
@@ -14,3 +14,4 @@ class Configuracao(Base):
     tags = Column(JSON, default=[])
     cargos = Column(JSON, default=[])
     funcoes = Column(JSON, default=[])
+    diluentes = Column(JSON, default=[])

--- a/src/schemas/configuracao.py
+++ b/src/schemas/configuracao.py
@@ -19,6 +19,7 @@ class ConfiguracaoBase(BaseModel):
     tags: List[str] = []
     cargos: List[str] = []
     funcoes: List[str] = []
+    diluentes: List[str] = []
 
     model_config = ConfigDict(from_attributes=True, alias_generator=to_camel, populate_by_name=True)
 

--- a/src/scripts/seed.py
+++ b/src/scripts/seed.py
@@ -29,6 +29,21 @@ TAGS_CONFIG = [
     "Laboratório Ciente", "Quimio Adiada", "Comunicado ao Paciente", "Virá Após a RDT"
 ]
 
+DILUENTES_CONFIG = [
+    "Soro Fisiológico 0,9% 50ml",
+    "Soro Fisiológico 0,9% 100ml",
+    "Soro Fisiológico 0,9% 250ml",
+    "Soro Fisiológico 0,9% 500ml",
+    "Soro Fisiológico 0,9% 1000ml",
+    "Glicose 5% 50ml",
+    "Glicose 5% 100ml",
+    "Glicose 5% 250ml",
+    "Glicose 5% 500ml",
+    "Glicose 5% 1000ml",
+    "Água para Injeção 10ml",
+    "Sem Diluente (Bolus)"
+]
+
 CARGOS = ["Enfermeiro", "Técnico de Enfermagem", "Farmacêutico", "Médico", "Administrador"]
 FUNCOES = ["Gestão", "Salão QT", "Triagem/Marcação", "Consulta de Enfermagem", "Apoio"]
 MEDICOS_USERNAMES = ["med.carlos", "med.fernanda", "med.roberto"]
@@ -80,6 +95,13 @@ def criar_prescricao_payload(protocolo_model: Protocolo, paciente: Paciente, med
                 elif dados.unidade == UnidadeDoseEnum.MG_KG:
                     dose_calc = dados.dose_referencia * paciente.peso
 
+                diluicao_padrao = ""
+                if hasattr(dados, 'configuracao_diluicao') and dados.configuracao_diluicao:
+                    config = dados.configuracao_diluicao
+                    diluicao_padrao = getattr(config, 'selecionada', "") or ""
+                    if not diluicao_padrao and hasattr(config, 'opcoes_permitidas') and config.opcoes_permitidas:
+                        diluicao_padrao = config.opcoes_permitidas[0]
+
                 item_p = ItemPrescricao(
                     id_item=str(uuid.uuid4()),
                     medicamento=dados.medicamento,
@@ -89,6 +111,7 @@ def criar_prescricao_payload(protocolo_model: Protocolo, paciente: Paciente, med
                     dose_final=round(dose_calc, 2),
                     via=dados.via,
                     tempo_minutos=dados.tempo_minutos,
+                    diluicao_final=diluicao_padrao,
                     dias_do_ciclo=dados.dias_do_ciclo,
                     notas_especificas=dados.notas_especificas
                 )
@@ -200,7 +223,8 @@ async def setup_app(aghu_pacientes):
             },
             tags=TAGS_CONFIG,
             cargos=CARGOS,
-            funcoes=FUNCOES
+            funcoes=FUNCOES,
+            diluentes=DILUENTES_CONFIG,
         )
         session.add(conf)
 


### PR DESCRIPTION
- Implementa `AjustesDiluentes.vue` para gerenciar a lista global de diluentes.
- Adiciona suporte para importação de diluentes via arquivo CSV com verificação de duplicatas.
- Substitui a lista estática de diluentes por dados persistidos no banco de dados.
- Adiciona sinalização visual de "INDISPONÍVEL" para diluentes em protocolos ou prescrições que não constam na lista global.
- Atualiza os schemas de backend e o script de seed para incluir a configuração de diluentes.
- Adiciona a unidade de medida no campo de creatinina no histórico de prescrições.