### PR TITLE
fix: corrige erro na importação de pacientes

### DIFF
--- a/frontend/src/components/pacientes/PacienteImportModal.vue
+++ b/frontend/src/components/pacientes/PacienteImportModal.vue
@@ -72,8 +72,7 @@ const handleImportarPaciente = async (pacienteExterno: PacienteImport) => {
         emit('update:open', false)
       }
     } else {
-      const detalhesCompletos = await api.get(`/api/pacientes/externo/${pacienteExterno.id}`)
-      const novoPaciente = await appStore.adicionarPaciente(detalhesCompletos.data)
+      const novoPaciente = await appStore.adicionarPaciente(pacienteExterno)
       toast.success(`Paciente ${pacienteExterno.nome} importado com sucesso!`)
       emit('paciente-importado', novoPaciente)
       emit('update:open', false)


### PR DESCRIPTION
Ao buscar a lista de pacientes externos já se obtém todos os dados necessários para a criação no banco de dados, então a nova chamada para obter esses dados não faz sentido. Além disso, devido ao próprio condicional, o id na chamada sempre era nulo.