### PR TITLE
Ações em lote e progresso da farmácia na agenda

### DIFF
--- a/frontend/src/components/agenda/AgendaCabecalho.vue
+++ b/frontend/src/components/agenda/AgendaCabecalho.vue
@@ -3,7 +3,7 @@ import {computed} from 'vue'
 import {Card, CardContent} from '@/components/ui/card'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
-import {ChevronLeft, ChevronRight, Eye, EyeOff, Plus} from 'lucide-vue-next'
+import {CalendarArrowDown, ChevronLeft, ChevronRight, Eye, EyeOff, Plus} from 'lucide-vue-next'
 
 const props = defineProps<{
   modelValue: string

--- a/frontend/src/components/agenda/AgendaTabela.vue
+++ b/frontend/src/components/agenda/AgendaTabela.vue
@@ -4,7 +4,7 @@ import {useRouter} from 'vue-router'
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table'
 import {Badge} from '@/components/ui/badge'
 import {Button} from '@/components/ui/button'
-import {ChevronDown, Clock, Tag} from 'lucide-vue-next'
+import {ChevronDown, Clock, Tag, Pill} from 'lucide-vue-next'
 import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from '@/components/ui/tooltip'
 import {Agendamento, TipoAgendamento} from "@/types/typesAgendamento.ts";
 import {
@@ -145,7 +145,8 @@ const getChecklistLabel = (agendamento: Agendamento) => {
             :key="ag.id"
             :class="{ 'bg-gray-50 opacity-60 grayscale': ag.status === 'remarcado' }"
         >
-          <TableCell class="text-center p-0 align-middle">
+          <TableCell class="text-center p-0 pl-2 align-middle relative">
+            <div v-if="tipo == 'infusao'" :class="['h-full w-[4px] absolute left-0 top-0 bottom-0', getAgendamentoInfo(ag).corBorda]"></div>
             <div class="flex items-center justify-center">
               <Checkbox
                   :checked="selectedSet.has(ag.id)"
@@ -153,8 +154,7 @@ const getChecklistLabel = (agendamento: Agendamento) => {
               />
             </div>
           </TableCell>
-          <TableCell class="p-0 relative">
-            <div v-if="tipo == 'infusao'" :class="['h-full w-[4px] absolute left-0 top-0 bottom-0', getAgendamentoInfo(ag).corBorda]"></div>
+          <TableCell class="p-0">
             <div class="px-4 pl-5">
               <button
                   class="text-md hover:text-blue-600 hover:underline"
@@ -171,7 +171,7 @@ const getChecklistLabel = (agendamento: Agendamento) => {
             </div>
           </TableCell>
 
-          <TableCell>
+          <TableCell class="py-0">
             <PacienteCelula
                 :nome="(ag.paciente?.nome) as string"
                 :observacoesClinicas="getObservacoesClinicas(ag)"
@@ -181,7 +181,7 @@ const getChecklistLabel = (agendamento: Agendamento) => {
             />
           </TableCell>
 
-          <TableCell class="align-center">
+          <TableCell class="align-center py-0">
             <div v-if="tipo == 'infusao'" class="flex flex-col truncate">
               <button
                   :title="ag.prescricao?.conteudo?.protocolo?.nome || '-'"
@@ -221,7 +221,7 @@ const getChecklistLabel = (agendamento: Agendamento) => {
             </div>
           </TableCell>
 
-          <TableCell>
+          <TableCell class="py-0">
             <div class="flex items-center gap-2">
               <div :class="['h-2.5 w-2.5 rounded-full flex-shrink-0', getStatusDotColor(ag.status)]"/>
 
@@ -248,8 +248,8 @@ const getChecklistLabel = (agendamento: Agendamento) => {
             </div>
           </TableCell>
 
-          <TableCell v-if="tipo=='infusao'" class="align-top">
-            <div class="flex flex-col gap-1">
+          <TableCell v-if="tipo=='infusao'" class="align-top py-1.5">
+            <div class="flex flex-col gap-0.5">
               <Badge
                   :class="[getFarmaciaStatusConfig(ag.detalhes?.infusao?.statusFarmacia).corBadge]"
                   class="w-fit font-semibold px-2 border uppercase hover:bg-opacity-100"
@@ -258,19 +258,20 @@ const getChecklistLabel = (agendamento: Agendamento) => {
                 {{ getFarmaciaStatusConfig(ag.detalhes?.infusao?.statusFarmacia).label }}
               </Badge>
 
-              <div class="pl-1 flex items-center gap-1.5 text-xs">
+              <div class="flex items-center gap-1 text-xs">
+                <Pill class="h-3 w-3 text-gray-400"/>
+                <span
+                    v-if="getChecklistLabel(ag)"
+                    class="font-medium text-gray-700 pr-1"
+                >
+                  {{ getChecklistLabel(ag) }}
+                </span>
                 <Clock class="h-3.5 w-3.5 text-gray-400"/>
-                <span v-if="ag.detalhes?.infusao?.horarioPrevisaoEntrega" class="text-blue-600 font-medium">
+                <span v-if="ag.detalhes?.infusao?.horarioPrevisaoEntrega" class="text-gray-700 font-medium">
                     {{ ag.detalhes.infusao.horarioPrevisaoEntrega }}
                 </span>
                 <span v-else class="text-gray-400 italic">
                   --:--
-                </span>
-                <span
-                    v-if="getChecklistLabel(ag)"
-                    class="ml-1 rounded bg-blue-50 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 border border-blue-100"
-                >
-                  {{ getChecklistLabel(ag) }}
                 </span>
               </div>
             </div>

--- a/frontend/src/components/farmacia/FarmaciaCabecalho.vue
+++ b/frontend/src/components/farmacia/FarmaciaCabecalho.vue
@@ -2,7 +2,7 @@
 import {Card, CardContent} from '@/components/ui/card'
 import {Button} from '@/components/ui/button'
 import {Input} from '@/components/ui/input'
-import {ChevronLeft, ChevronRight, Eye, EyeOff} from 'lucide-vue-next'
+import {CalendarArrowDown, ChevronLeft, ChevronRight, Eye, EyeOff} from 'lucide-vue-next'
 
 defineProps<{
   modelValue: string

--- a/frontend/src/stores/storeAgendamento.ts
+++ b/frontend/src/stores/storeAgendamento.ts
@@ -213,6 +213,36 @@ export const useAgendamentoStore = defineStore('agendamento', () => {
     }
   }
 
+  async function atualizarAgendamentosEmLote(itens: { id: string, [key: string]: any }[]) {
+    try {
+      const payload = {
+        itens: itens
+      }
+
+      const res = await api.put('/api/agendamentos/lote', payload)
+      const atualizados = res.data as Agendamento[]
+
+      atualizados.forEach(atualizado => {
+        const idx = agendamentos.value.findIndex(a => a.id === atualizado.id)
+        if (idx !== -1) {
+          const prescricaoAntiga = agendamentos.value[idx].prescricao
+          agendamentos.value[idx] = { ...atualizado, prescricao: prescricaoAntiga }
+        }
+      })
+
+      toast.success(`${atualizados.length} agendamentos atualizados`)
+      return atualizados
+    } catch (e: any) {
+      console.error(e)
+      if (e.response?.data?.detail) {
+          toast.error(e.response.data.detail)
+      } else {
+          toast.error("Erro ao atualizar agendamentos em lote")
+      }
+      throw e
+    }
+  }
+
   return {
     agendamentos,
     getAgendamentosDoDia,
@@ -224,6 +254,7 @@ export const useAgendamentoStore = defineStore('agendamento', () => {
     atualizarHorarioPrevisao,
     remarcarAgendamento,
     atualizarTagsAgendamento,
+    atualizarAgendamentosEmLote,
     salvarChecklistFarmacia
   }
 })

--- a/frontend/src/stores/storeGeral.ts
+++ b/frontend/src/stores/storeGeral.ts
@@ -59,6 +59,7 @@ export const useAppStore = defineStore('app', () => {
     atualizarHorarioPrevisao,
     remarcarAgendamento,
     atualizarTagsAgendamento,
+    atualizarAgendamentosEmLote,
     salvarChecklistFarmacia
   } = agendamentoStore
 
@@ -94,6 +95,7 @@ export const useAppStore = defineStore('app', () => {
     atualizarHorarioPrevisao,
     remarcarAgendamento,
     atualizarTagsAgendamento,
+    atualizarAgendamentosEmLote,
     salvarChecklistFarmacia,
 
     fetchProtocolos,

--- a/src/controllers/agendamento_controller.py
+++ b/src/controllers/agendamento_controller.py
@@ -8,8 +8,77 @@ from sqlalchemy.orm.attributes import flag_modified
 from src.models.agendamento import Agendamento
 from src.providers.interfaces.agendamento_provider_interface import AgendamentoProviderInterface
 from src.providers.interfaces.prescricao_provider_interface import PrescricaoProviderInterface
-from src.schemas.agendamento import AgendamentoCreate, AgendamentoUpdate, AgendamentoResponse, TipoAgendamento
+from src.schemas.agendamento import AgendamentoCreate, AgendamentoUpdate, AgendamentoResponse, TipoAgendamento, \
+    AgendamentoBulkUpdateList
 from src.schemas.prescricao import PrescricaoResponse
+
+def _aplicar_regras_atualizacao(agendamento: Agendamento, update_data: dict):
+    if 'tipo' in update_data:
+        if update_data['tipo'] != agendamento.tipo:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Não é permitido alterar o tipo de um agendamento. Cancele este e crie um novo."
+            )
+        del update_data['tipo']
+
+    novo_status = update_data.get('status', agendamento.status)
+    novo_checkin = update_data.get('checkin', agendamento.checkin)
+
+    status_permitidos_sem_checkin = [
+        'agendado',
+        'aguardando-consulta',
+        'aguardando-exame',
+        'aguardando-medicamento',
+        'internado',
+        'suspenso',
+        'remarcado'
+    ]
+
+    if not novo_checkin and novo_status not in status_permitidos_sem_checkin:
+        if 'checkin' in update_data and update_data['checkin'] is False:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Não é possível remover o Check-in enquanto o paciente estiver com status '{novo_status}'."
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"O status '{novo_status}' exige que o paciente tenha realizado o Check-in."
+            )
+
+    if 'detalhes' in update_data:
+        novos_detalhes = update_data['detalhes']
+        detalhes_atuais = dict(agendamento.detalhes) if agendamento.detalhes else {}
+
+        mapa_tipo_chave = {
+            TipoAgendamento.INFUSAO.value: 'infusao',
+            TipoAgendamento.PROCEDIMENTO.value: 'procedimento',
+            TipoAgendamento.CONSULTA.value: 'consulta'
+        }
+        tipo_chave_principal = mapa_tipo_chave.get(agendamento.tipo)
+        chaves_proibidas = {v for k, v in mapa_tipo_chave.items() if v != tipo_chave_principal}
+
+        for chave in novos_detalhes.keys():
+            if chave in chaves_proibidas:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Agendamento do tipo {agendamento.tipo} não pode ter detalhes de {chave}."
+                )
+
+        for chave, valor_novo in novos_detalhes.items():
+            valor_atual = detalhes_atuais.get(chave)
+            if isinstance(valor_atual, dict) and isinstance(valor_novo, dict):
+                valor_atual.update(valor_novo)
+            else:
+                detalhes_atuais[chave] = valor_novo
+
+        update_data['detalhes'] = detalhes_atuais
+
+    for key, value in update_data.items():
+        setattr(agendamento, key, value)
+
+    if 'detalhes' in update_data:
+        flag_modified(agendamento, "detalhes")
 
 
 async def listar_agendamentos(
@@ -110,73 +179,31 @@ async def atualizar_agendamento(provider: AgendamentoProviderInterface, agendame
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agendamento não encontrado")
 
     update_data = dados.model_dump(exclude_unset=True)
-
-    if 'tipo' in update_data:
-        if update_data['tipo'] != agendamento.tipo:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Não é permitido alterar o tipo de um agendamento. Cancele este e crie um novo."
-            )
-        del update_data['tipo']
-
-    novo_status = update_data.get('status', agendamento.status)
-    novo_checkin = update_data.get('checkin', agendamento.checkin)
-
-    status_permitidos_sem_checkin = [
-        'agendado',
-        'aguardando-consulta',
-        'aguardando-exame',
-        'aguardando-medicamento',
-        'internado',
-        'suspenso',
-        'remarcado'
-    ]
-
-    if not novo_checkin and novo_status not in status_permitidos_sem_checkin:
-        if 'checkin' in update_data and update_data['checkin'] is False:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Não é possível remover o Check-in enquanto o paciente estiver com status '{novo_status}'."
-            )
-        else:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"O status '{novo_status}' exige que o paciente tenha realizado o Check-in."
-            )
-
-    if 'detalhes' in update_data:
-        novos_detalhes = update_data['detalhes']
-        detalhes_atuais = dict(agendamento.detalhes) if agendamento.detalhes else {}
-
-        mapa_tipo_chave = {
-            TipoAgendamento.INFUSAO.value: 'infusao',
-            TipoAgendamento.PROCEDIMENTO.value: 'procedimento',
-            TipoAgendamento.CONSULTA.value: 'consulta'
-        }
-        tipo_chave_principal = mapa_tipo_chave.get(agendamento.tipo)
-        chaves_proibidas = {v for k, v in mapa_tipo_chave.items() if v != tipo_chave_principal}
-
-        for chave in novos_detalhes.keys():
-            if chave in chaves_proibidas:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Agendamento do tipo {agendamento.tipo} não pode ter detalhes de {chave}."
-                )
-
-        for chave, valor_novo in novos_detalhes.items():
-            valor_atual = detalhes_atuais.get(chave)
-            if isinstance(valor_atual, dict) and isinstance(valor_novo, dict):
-                valor_atual.update(valor_novo)
-            else:
-                detalhes_atuais[chave] = valor_novo
-
-        update_data['detalhes'] = detalhes_atuais
-
-    for key, value in update_data.items():
-        setattr(agendamento, key, value)
-
-    if 'detalhes' in update_data:
-        flag_modified(agendamento, "detalhes")
-
+    _aplicar_regras_atualizacao(agendamento, update_data)
     atualizado = await provider.atualizar_agendamento(agendamento)
     return AgendamentoResponse.model_validate(atualizado)
+
+
+async def atualizar_agendamentos_lote(
+        provider: AgendamentoProviderInterface,
+        dados_lote: AgendamentoBulkUpdateList
+) -> List[AgendamentoResponse]:
+    ids = [item.id for item in dados_lote.itens]
+    agendamentos_existentes = await provider.buscar_por_id_multi(ids)
+    mapa_agendamentos = {a.id: a for a in agendamentos_existentes}
+
+    if len(mapa_agendamentos) != len(set(ids)):
+        ids_encontrados = set(mapa_agendamentos.keys())
+        ids_faltantes = set(ids) - ids_encontrados
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agendamentos não encontrados: {', '.join(ids_faltantes)}"
+        )
+
+    for item_update in dados_lote.itens:
+        agendamento = mapa_agendamentos[item_update.id]
+        update_data = item_update.model_dump(exclude={'id'}, exclude_unset=True)
+        _aplicar_regras_atualizacao(agendamento, update_data)
+
+    atualizados = await provider.atualizar_agendamento_multi(list(mapa_agendamentos.values()))
+    return [AgendamentoResponse.model_validate(a) for a in atualizados]

--- a/src/providers/implementations/agendamento_sqlalchemy_provider.py
+++ b/src/providers/implementations/agendamento_sqlalchemy_provider.py
@@ -33,6 +33,11 @@ class AgendamentoSQLAlchemyProvider(AgendamentoProviderInterface):
         result = await self.session.execute(query)
         return result.scalar_one_or_none()
 
+    async def buscar_por_id_multi(self, ids: List[str]) -> List[Agendamento]:
+        query = select(Agendamento).where(Agendamento.id.in_(ids)).options(selectinload(Agendamento.paciente), selectinload(Agendamento.criado_por))
+        result = await self.session.execute(query)
+        return result.scalars().all()
+
 
     async def buscar_por_prescricao_e_dia(self, prescricao_id: str, dia_ciclo: int) -> List[Agendamento]:
         query = select(Agendamento).where(
@@ -58,3 +63,8 @@ class AgendamentoSQLAlchemyProvider(AgendamentoProviderInterface):
         query = select(Agendamento).where(Agendamento.id == agendamento.id).options(selectinload(Agendamento.paciente), selectinload(Agendamento.criado_por))
         result = await self.session.execute(query)
         return result.scalar_one()
+
+    async def atualizar_agendamento_multi(self, agendamentos: List[Agendamento]) -> List[Agendamento]:
+        await self.session.commit()
+        ids = [a.id for a in agendamentos]
+        return await self.buscar_por_id_multi(ids)

--- a/src/providers/interfaces/agendamento_provider_interface.py
+++ b/src/providers/interfaces/agendamento_provider_interface.py
@@ -22,6 +22,10 @@ class AgendamentoProviderInterface(ABC):
         pass
 
     @abstractmethod
+    async def buscar_por_id_multi(self, ids: List[str]) -> List[Agendamento]:
+        pass
+
+    @abstractmethod
     async def buscar_por_prescricao_e_dia(
             self,
             prescricao_id: str,
@@ -39,4 +43,8 @@ class AgendamentoProviderInterface(ABC):
     async def atualizar_agendamento(
             self, agendamento: Agendamento,
     ) -> Agendamento:
+        pass
+
+    @abstractmethod
+    async def atualizar_agendamento_multi(self, agendamentos: List[Agendamento]) -> List[Agendamento]:
         pass

--- a/src/routers/agendamento.py
+++ b/src/routers/agendamento.py
@@ -8,7 +8,7 @@ from src.controllers import agendamento_controller
 from src.dependencies import get_agendamento_provider, get_prescricao_provider
 from src.providers.interfaces.agendamento_provider_interface import AgendamentoProviderInterface
 from src.providers.interfaces.prescricao_provider_interface import PrescricaoProviderInterface
-from src.schemas.agendamento import AgendamentoCreate, AgendamentoUpdate, AgendamentoResponse
+from src.schemas.agendamento import AgendamentoCreate, AgendamentoUpdate, AgendamentoResponse, AgendamentoBulkUpdateList
 
 router = APIRouter(prefix="/api/agendamentos", tags=["Agendamentos"], dependencies=[Depends(auth_handler.decode_token)])
 
@@ -46,6 +46,14 @@ async def criar_agendamento(
         dados,
         criado_por_id=user_id,
     )
+
+
+@router.put("/lote", response_model=List[AgendamentoResponse])
+async def atualizar_agendamentos_em_lote(
+    dados: AgendamentoBulkUpdateList,
+    provider: AgendamentoProviderInterface = Depends(get_agendamento_provider)
+):
+    return await agendamento_controller.atualizar_agendamentos_lote(provider, dados)
 
 
 @router.put("/{agendamento_id}", response_model=AgendamentoResponse)

--- a/src/schemas/agendamento.py
+++ b/src/schemas/agendamento.py
@@ -224,6 +224,14 @@ class AgendamentoPaciente(BaseSchema):
     observacoes_clinicas: Optional[str] = None
 
 
+class AgendamentoBulkUpdateItem(AgendamentoUpdate):
+    id: str
+
+
+class AgendamentoBulkUpdateList(BaseSchema):
+    itens: List[AgendamentoBulkUpdateItem]
+
+
 class AgendamentoResponse(AgendamentoBase):
     id: str
     criado_por_id: Optional[str] = None


### PR DESCRIPTION
Este conjunto de alterações implementa a gestão de agendamentos em massa e a visualização do status de preparação de medicamentos.

### Alterações principais

**Ações em lote (Frontend e Backend)**

- Implementada seleção múltipla nas tabelas de Agenda e Farmácia.
- Adicionada barra de ações para atualização de status em massa.
- Criado endpoint `PUT /api/agendamentos/lote` para processamento atômico de atualizações no backend.
- Refatorada a lógica de validação de agendamentos para suportar tanto atualizações unitárias quanto em lote no controlador.



**Progresso da farmácia na agenda**

- Adicionado indicador visual na agenda mostrando o checklist de medicamentos (ex: "1/4").
- O contador é exibido junto à previsão de entrega para agendamentos de infusão.



### Notas técnicas

- A remarcação em lote é processada individualmente pelo frontend. Não foi desenvolvido um endpoint específico de remarcação em lote no backend devido a discussões pendentes em outra issue sobre o fluxo de remarcação.

- O sistema de permissões de check-in foi mantido e validado para operações em lote.


Closes #87, Closes #81.