### PR TITLE
refactor: separa containers de desenvolvimento

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Banco da Aplicação (Agendamentos, Prescrições, Pacientes Locais)
+APP_DB_URL=postgresql+asyncpg://user:password@localhost:5432/db_quimio
+
+# Banco Legado Simulado (AGHU) - Apenas Leitura para Importação
+AGHU_DB_URL=postgresql+asyncpg://user:password@localhost:5433/db_aghu
+
+# Autenticação via Active Directory
+AD_SERVER=ldap://localhost:3389
+AD_DOMAIN=hc.gov.br
+AD_BASEDN=dc=hc,dc=gov,dc=br
+AD_ADMIN_DN=cn=admin,dc=hc,dc=gov,dc=br
+AD_ADMIN_PASSWORD=admin
+ROLES_MAP_PATH=src/roles_map.json
+
+# JWT
+JWT_SECRET=SUA_CHAVE_SECRETA_SUPER_FORTE_AQUI
+JWT_EXP_MINUTES=60
+JWT_REFRESH_TOKEN_EXP_DAYS=7

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,57 @@
+version: '3.8'
+
+services:
+  db_aghu:
+    image: postgres:15-alpine
+    container_name: quimio_db_aghu
+    volumes:
+      - postgres_aghu_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=db_aghu
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U user -d db_aghu" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - quimio_network
+
+  ldap:
+    image: osixia/openldap:latest
+    container_name: openldap_server
+    environment:
+      LDAP_ORGANISATION: "Hospital"
+      LDAP_DOMAIN: "hc.gov.br"
+      LDAP_ADMIN_PASSWORD: "admin"
+      LDAP_RFC2307BIS_SCHEMA: "true"
+    volumes:
+      - ./ldap_bootstrap:/container/service/slapd/assets/config/bootstrap/ldif/custom:Z
+    ports:
+      - "3389:389"
+      - "3636:636"
+    command: --copy-service
+    networks:
+      - quimio_network
+
+  ldap-admin:
+    image: osixia/phpldapadmin:latest
+    container_name: phpldapadmin
+    environment:
+      PHPLDAPADMIN_LDAP_HOSTS: "ldap"
+      PHPLDAPADMIN_HTTPS: "false"
+    ports:
+      - "8081:80"
+    depends_on:
+      - ldap
+    networks:
+      - quimio_network
+
+volumes:
+  postgres_aghu_data:
+
+networks:
+  quimio_network: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,11 @@
 version: '3.8'
 
 services:
-  db:
+  db_app:
     image: postgres:15-alpine
+    container_name: quimio_db_app
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - postgres_app_data:/var/lib/postgresql/data/
     environment:
       - POSTGRES_USER=user
       - POSTGRES_PASSWORD=password
@@ -12,36 +13,16 @@ services:
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U user -d db_quimio"]
+      test: [ "CMD-SHELL", "pg_isready -U user -d db_quimio" ]
       interval: 5s
       timeout: 5s
       retries: 5
-
-  ldap:
-    image: osixia/openldap:latest
-    container_name: openldap_server
-    environment:
-      LDAP_ORGANISATION: "Hospital"
-      LDAP_DOMAIN: "hc.gov.br"
-      LDAP_ADMIN_PASSWORD: "admin"
-      LDAP_RFC2307BIS_SCHEMA: "true"
-    volumes:
-      - ./ldap_bootstrap:/container/service/slapd/assets/config/bootstrap/ldif/custom:Z
-    ports:
-      - "3389:389"
-      - "3636:636"
-    command: --copy-service
-
-  ldap-admin:
-    image: osixia/phpldapadmin:latest
-    container_name: phpldapadmin
-    environment:
-      PHPLDAPADMIN_LDAP_HOSTS: "ldap"
-      PHPLDAPADMIN_HTTPS: "false"
-    ports:
-      - "8081:80"
-    depends_on:
-      - ldap
+    networks:
+      - quimio_network
 
 volumes:
-  postgres_data:
+  postgres_app_data:
+
+networks:
+  quimio_network:
+    driver: bridge

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,7 +1,5 @@
 # Banco de Dados e Migrações
 
-Este documento explica a arquitetura de dados do projeto e como gerenciar as alterações no esquema do banco de dados utilizando o **Alembic**.
-
 ## Arquitetura de Dados
 
 O sistema interage com duas fontes de dados distintas (ambas PostgreSQL em desenvolvimento):
@@ -18,66 +16,26 @@ O sistema interage com duas fontes de dados distintas (ambas PostgreSQL em desen
 
 ---
 
-## Gerenciando Migrações (Alembic)
-
-As migrações controlam apenas o banco `db_quimio`.
-
-### Comandos Principais
-
-#### Criar uma nova migração
-Sempre que um modelo em `src/models/` é alterado, uma nova revisão deve ser gerada:
-
-```bash
-alembic revision --autogenerate -m "descricao_da_mudanca"
-```
-
-*O arquivo gerado em `alembic/versions/` deve ser verificado para garantir que o script está correto.*
-
-#### Aplicar migrações (Atualizar o banco)
-
-Para aplicar as mudanças pendentes no banco de dados:
-
-```bash
-alembic upgrade head
-```
-
-#### Reverter migrações
-
-Para desfazer a última migração aplicada:
-
-```bash
-alembic downgrade -1
-```
-
-Ou para voltar ao estado zero (cuidado, apaga todos os dados):
-
-```bash
-alembic downgrade base
-```
-
----
-
 ## Resetando o Ambiente de Dados (Desenvolvimento)
 
 Se o banco de dados local estiver inconsistente ou seja necessário começar "do zero":
 
 1. **Pare os containers e apague os volumes:**
-Isso apaga fisicamente os dados do container.
-```bash
-podman-compose down -v
-```
+    Isso apaga fisicamente os dados do container.
+    ```bash
+    podman-compose down -v
+    ```
 
 2. **Inicie novamente:**
-```bash
-podman-compose up --build
-```
+    ```bash
+    podman-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+    ```
 
-3. **Recrie o banco legado:**
-```bash
-podman-compose exec db psql -U user -d postgres -c "CREATE DATABASE db_aghu;"
-```
+3. **Execute os scripts de seed:**
+    ```bash
+    # Primeiro popular o AGHU (Executar apenas uma vez ou se resetar volumes)
+    python src/scripts/seed_aghu.py
 
-4. **Execute as migrações e seeds:**
-```bash
-python src/scripts/seed_dev.py
-```
+    # Depois popular o banco da aplicação (Desenvolvimento diário)
+    python src/scripts/seed_dev.py
+    ```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -11,34 +11,27 @@ Este guia detalha como configurar o ambiente de desenvolvimento. Atualmente, uti
 
 ---
 
-## 1. Configuração dos Bancos de Dados
+## 1. Configuração dos Containers
 
-O projeto depende de dois bancos de dados PostgreSQL que rodam no mesmo container:
+O projeto depende de dois bancos de dados PostgreSQL e dos serviços LDAP:
 1.  `db_quimio`: Banco de dados principal da aplicação.
 2.  `db_aghu`: Banco de dados que simula o sistema legado do hospital (apenas leitura/validação).
+3.  `openldap_server`: Servidor LDAP para autenticação.
+4.  `phpldapadmin`: Interface web para o servidor LDAP.
 
-### Passo a passo:
+### Alternativas:
 
-1.  **Inicie o container do banco de dados:**
+1.  **Inicie todos os serviços no ambiente de desenvolvimento:**
+    Na raiz do projeto, execute:
+    ```bash
+    podman-compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+    ```
+
+2.  **Inicie apenas o banco de dados principal em produção:**
     Na raiz do projeto, execute:
     ```bash
     podman-compose up --build
     ```
-
-2.  **Verifique/Crie o banco legado (`db_aghu`):**
-    O container padrão cria apenas o `db_quimio`. Você precisa criar o segundo banco manualmente na primeira vez.
-
-    Execute o comando abaixo para criar o `db_aghu`:
-    ```bash
-    podman-compose exec db psql -U user -d postgres -c "CREATE DATABASE db_aghu;"
-    ```
-    *Se retornar um erro dizendo que o banco já existe, pode ignorar.*
-
-3.  **Confira se ambos existem:**
-    ```bash
-    podman-compose exec db psql -U user -l
-    ```
-    Você deve ver `db_quimio` e `db_aghu` na lista.
 
 ---
 
@@ -64,7 +57,10 @@ O projeto depende de dois bancos de dados PostgreSQL que rodam no mesmo containe
 4.  **Popule os bancos de dados (Seeds):**
     Para ter dados iniciais para trabalhar:
     ```bash
-    # Popula o banco de dados com pacientes/prescrições simulados
+    # Primeiro popular o AGHU (Executar apenas uma vez ou se resetar volumes)
+    python src/scripts/seed_aghu.py
+
+    # Depois popular o banco da aplicação (Desenvolvimento diário)
     python src/scripts/seed_dev.py
     ```
 

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,9 +1,0 @@
-# Banco da Aplicação (Agendamentos, Prescrições, Pacientes Locais)
-APP_DB_URL=postgresql+asyncpg://user:password@localhost:5432/db_quimio
-
-# Banco Legado Simulado (AGHU) - Apenas Leitura para Importação
-AGHU_DB_URL=postgresql+asyncpg://user:password@localhost:5432/db_aghu
-
-JWT_SECRET=SUA_CHAVE_SECRETA_SUPER_FORTE_AQUI
-JWT_EXP_HOURS=24
-REFRESH_TOKEN_EXP_DAYS=30


### PR DESCRIPTION
- Divide o `docker-compose.yml` em dois arquivos para isolar o banco da aplicação dos serviços de suporte (AGHU e LDAP).
- Remove a necessidade de criação manual do banco `db_aghu`, utilizando variáveis de ambiente para inicialização automática no container.
- Atualiza `.env.example` com as novas portas (AGHU em `5433`) e ajusta a rede `quimio_network` para comunicação entre arquivos compose.
- Atualiza os guias `SETUP.md` e `DATABASE.md` com os novos comandos de execução e o fluxo de *seed* dividido em duas etapas.